### PR TITLE
Add SQLite persistence scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Yetla 管理平台示例环境变量
+ADMIN_USER=admin
+ADMIN_PASS=changeme
+BASE_DOMAIN=yet.la
+SHORT_CODE_LEN=6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@
 
 ## 2025-10-03
 - 初始化变更日志，标记 server-side redirects 工作流基线。
+
+## 2025-10-04
+- 引入 SQLite 数据库初始化逻辑，新增 `SubdomainRedirect` 与 `ShortLink` 模型。
+- 新增 `.env.example` 与文档说明，约定数据文件挂载到 `./data`。

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ http://yet.la:8080          # 默认站点
 
 FastAPI 接口可通过 `http://localhost:8000/routes` 查看当前子域映射。
 
+## 环境变量
+
+项目根目录提供了示例文件 [`.env.example`](.env.example)，可复制为 `.env` 并根据实际情况调整：
+
+| 变量名 | 说明 |
+| --- | --- |
+| `ADMIN_USER` | 后台登录用户名（占位值，后续接入鉴权时使用）。 |
+| `ADMIN_PASS` | 后台登录密码。 |
+| `BASE_DOMAIN` | 系统管理的基础域名，例如 `yet.la`。 |
+| `SHORT_CODE_LEN` | 生成短链接时的默认编码长度，默认 `6`。 |
+
+当前版本尚未读取这些值，但通过 `.env` 预留了部署所需的配置位点，方便后续迭代直接启用。
+
+## 数据存储
+
+- 后端默认使用 SQLite，数据库文件位于容器内的 `/data/data.db`。
+- `docker-compose.yml` 将仓库根目录的 `./data` 映射到容器 `/data`，首次启动 FastAPI 时会自动创建数据库文件和所需表结构（`subdomain_redirects`、`short_links`）。
+- 若需备份或迁移，可直接复制 `data/data.db`。
+
 ## 部署建议
 
 1. **自动生成配置**：未来可由后端根据数据库记录渲染 Nginx 模板，再通过 CI/CD 分发。

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from .models import Base, engine
+
 app = FastAPI(
     title="Yetla Subdomain Router API",
     description=(
@@ -12,6 +14,13 @@ app = FastAPI(
     ),
     version="0.1.0",
 )
+
+
+@app.on_event("startup")
+def ensure_tables() -> None:
+    """应用启动时自动创建数据库表。"""
+
+    Base.metadata.create_all(bind=engine)
 
 
 class Route(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,56 @@
+"""数据库模型与引擎配置。"""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:////data/data.db")
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy Declarative 基类。"""
+
+
+engine = create_engine(
+    DATABASE_URL,
+    echo=False,
+    future=True,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+class SubdomainRedirect(Base):
+    """子域名重定向规则。"""
+
+    __tablename__ = "subdomain_redirects"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    host: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    target_url: Mapped[str] = mapped_column(String(2048))
+    code: Mapped[int] = mapped_column("code_int", Integer, default=302, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class ShortLink(Base):
+    """短链接记录表。"""
+
+    __tablename__ = "short_links"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    code: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    target_url: Mapped[str] = mapped_column(String(2048))
+    hits: Mapped[int] = mapped_column("hits_int", Integer, default=0, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,25 @@
+"""Pydantic schema 定义。"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SubdomainRedirect(BaseModel):
+    host: str = Field(..., description="例如 api.yet.la")
+    target_url: str = Field(..., description="完整跳转地址")
+    code: int = Field(default=302, description="HTTP 状态码")
+    created_at: datetime = Field(..., description="创建时间")
+
+    model_config = {"from_attributes": True}
+
+
+class ShortLink(BaseModel):
+    code: str = Field(..., description="短链编码")
+    target_url: str = Field(..., description="目标地址")
+    hits: int = Field(default=0, description="访问次数")
+    created_at: datetime = Field(..., description="创建时间")
+
+    model_config = {"from_attributes": True}
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.110.0
 uvicorn[standard]==0.29.0
 pydantic==2.6.4
+sqlalchemy==2.0.29

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,3 +37,5 @@ services:
     ports:
       - "8000:8000"
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    volumes:
+      - ./data:/data


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy models for subdomain redirects and short links, with automatic table creation on startup
- provide companion Pydantic schemas, example environment variables, and mount the /data volume for the backend container
- document the new configuration and storage expectations and record the change in the changelog

## Testing
- ⚠️ `python - <<'PY'
from backend.app.models import Base, engine

Base.metadata.create_all(bind=engine)
print("tables:", engine.inspect(engine).get_table_names())
PY` *(fails: ModuleNotFoundError: No module named 'sqlalchemy' in the execution environment)*
- ⚠️ `docker compose up -d --build` *(fails: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df38d293f0832f92911871d6209731