### PR TITLE
feat: secure redirect api with basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,8 @@
 ## 2025-10-04
 - 引入 SQLite 数据库初始化逻辑，新增 `SubdomainRedirect` 与 `ShortLink` 模型。
 - 新增 `.env.example` 与文档说明，约定数据文件挂载到 `./data`。
+
+## 2025-10-05
+- 为 FastAPI 应用实现短链接与子域 CRUD 接口，新增 HTTP Basic 认证保护 `/api/*` 与 `/admin`。
+- 增加 `/healthz`、`/r/{code}` 与 Host 通配跳转路由，未命中返回 404 文本。
+- README 增补接口表与 `curl` 示例，便于人工自测。

--- a/README.md
+++ b/README.md
@@ -50,6 +50,54 @@ http://yet.la:8080          # 默认站点
 
 FastAPI 接口可通过 `http://localhost:8000/routes` 查看当前子域映射。
 
+## API 说明与示例 curl
+
+`backend/app/main.py` 提供了公开与受保护的接口组合：
+
+| Method | Path | 说明 | 认证 | 常见返回码 |
+| --- | --- | --- | --- | --- |
+| GET | `/healthz` | 健康检查 | 无 | 200 |
+| GET | `/routes` | 查询所有子域跳转规则 | 无 | 200 |
+| GET | `/api/links` | 列出短链接 | HTTP Basic | 200 |
+| POST | `/api/links` | 新增短链接（`code` 为空时自动生成） | HTTP Basic | 201 / 409 |
+| DELETE | `/api/links/{id}` | 删除短链接 | HTTP Basic | 204 / 404 |
+| GET | `/api/subdomains` | 列出子域跳转 | HTTP Basic | 200 |
+| POST | `/api/subdomains` | 新增子域跳转（`host` 为完整域名） | HTTP Basic | 201 / 409 |
+| DELETE | `/api/subdomains/{id}` | 删除子域跳转 | HTTP Basic | 204 / 404 |
+| GET | `/r/{code}` | 短链接跳转并累积访问量 | 无 | 302 / 404 |
+
+> 🔐 受保护接口通过 HTTP Basic 认证，默认凭据来自 `ADMIN_USER` / `ADMIN_PASS` 环境变量（若未配置则为 `admin/admin`）。
+
+以下示例演示常见调用流程（假设服务运行在本地 8000 端口）：
+
+```bash
+# 健康检查与公开路由
+curl http://localhost:8000/healthz
+curl http://localhost:8000/routes
+
+# 创建短链接（code 为空自动生成）、查询并删除
+curl -u admin:admin \
+  -H "Content-Type: application/json" \
+  -d '{"target_url":"https://yet.la/docs"}' \
+  http://localhost:8000/api/links
+curl -u admin:admin http://localhost:8000/api/links
+curl -u admin:admin -X DELETE http://localhost:8000/api/links/1
+
+# 创建子域跳转，随后通过 Host 头验证跳转
+curl -u admin:admin \
+  -H "Content-Type: application/json" \
+  -d '{"host":"docs.yet.la","target_url":"https://yet.la/docs","code":302}' \
+  http://localhost:8000/api/subdomains
+curl -u admin:admin http://localhost:8000/api/subdomains
+curl -I -H "Host: docs.yet.la" http://localhost:8000/
+curl -u admin:admin -X DELETE http://localhost:8000/api/subdomains/1
+
+# 短链接跳转与命中次数（将 <code> 替换为查询结果中的实际值）
+curl -I http://localhost:8000/r/<code>
+```
+
+> 在上述示例中，`curl -I -H "Host: docs.yet.la" http://localhost:8000/` 会命中通配路由并返回数据库配置的 301/302 跳转。
+
 ## 环境变量
 
 项目根目录提供了示例文件 [`.env.example`](.env.example)，可复制为 `.env` 并根据实际情况调整：
@@ -61,7 +109,7 @@ FastAPI 接口可通过 `http://localhost:8000/routes` 查看当前子域映射�
 | `BASE_DOMAIN` | 系统管理的基础域名，例如 `yet.la`。 |
 | `SHORT_CODE_LEN` | 生成短链接时的默认编码长度，默认 `6`。 |
 
-当前版本尚未读取这些值，但通过 `.env` 预留了部署所需的配置位点，方便后续迭代直接启用。
+当前版本会读取 `ADMIN_USER` / `ADMIN_PASS` 作为 Basic Auth 凭据，并使用 `SHORT_CODE_LEN` 控制自动生成短码长度；其余变量仍预留以便后续扩展。
 
 ## 数据存储
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,21 +3,57 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
-class SubdomainRedirect(BaseModel):
+class SubdomainRedirectBase(BaseModel):
     host: str = Field(..., description="例如 api.yet.la")
     target_url: str = Field(..., description="完整跳转地址")
     code: int = Field(default=302, description="HTTP 状态码")
+
+    @field_validator("host")
+    @classmethod
+    def _normalize_host(cls, value: str) -> str:
+        return value.strip().lower()
+
+    @field_validator("code")
+    @classmethod
+    def _validate_code(cls, value: int) -> int:
+        if value not in {301, 302}:
+            raise ValueError("仅支持 301 或 302 重定向")
+        return value
+
+
+class SubdomainRedirect(SubdomainRedirectBase):
+    id: int = Field(..., description="数据库主键")
     created_at: datetime = Field(..., description="创建时间")
 
     model_config = {"from_attributes": True}
 
 
-class ShortLink(BaseModel):
-    code: str = Field(..., description="短链编码")
+class SubdomainRedirectCreate(SubdomainRedirectBase):
+    pass
+
+
+class ShortLinkBase(BaseModel):
     target_url: str = Field(..., description="目标地址")
+
+
+class ShortLinkCreate(ShortLinkBase):
+    code: str | None = Field(default=None, description="短链编码，可为空自动生成")
+
+    @field_validator("code")
+    @classmethod
+    def _normalize_code(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+
+class ShortLink(ShortLinkBase):
+    id: int = Field(..., description="数据库主键")
+    code: str = Field(..., description="短链编码")
     hits: int = Field(default=0, description="访问次数")
     created_at: datetime = Field(..., description="创建时间")
 


### PR DESCRIPTION
## Summary
- add HTTP Basic-protected CRUD endpoints for short links and subdomain redirects, alongside public `/healthz`, `/routes`, `/r/{code}` and host-based catch-all redirect responses (200/201/204/302/404/409)
- enforce common 404/409 payloads, automatic code generation, and hit counting while reusing SQLAlchemy models
- document the API surface with a method/status table, curl walkthrough, and changelog entry

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_b_68df3a4de818832fba2aa2c46e8709d9