### PR TITLE
test: add backend pytest coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ curl -I http://localhost:8000/r/<code>
 
 > 在上述示例中，`curl -I -H "Host: docs.yet.la" http://localhost:8000/` 会命中通配路由并返回数据库配置的 301/302 跳转。
 
+## 测试运行
+
+后端项目内置了一组 Pytest 用例，用于验证短链 CRUD、子域跳转、认证与公开路由等核心行为。执行方式如下：
+
+```bash
+# 安装依赖
+pip install -r backend/requirements.txt
+
+# 在本机直接运行
+pytest -q
+
+# 若通过 Docker Compose 部署了后端容器，也可在容器内执行
+docker compose exec backend pytest -q
+```
+
 ## 环境变量
 
 项目根目录提供了示例文件 [`.env.example`](.env.example)，可复制为 `.env` 并根据实际情况调整：

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,5 @@ fastapi==0.110.0
 uvicorn[standard]==0.29.0
 pydantic==2.6.4
 sqlalchemy==2.0.29
+pytest==8.1.1
+httpx==0.27.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import pytest
+from sqlalchemy import delete
+
+TEST_DB_PATH = Path(__file__).resolve().parent / "test.db"
+if TEST_DB_PATH.exists():
+    TEST_DB_PATH.unlink()
+os.environ["DATABASE_URL"] = f"sqlite:///{TEST_DB_PATH}"
+
+from backend.app.main import app  # noqa: E402  pylint: disable=wrong-import-position
+from backend.app.models import (  # noqa: E402  pylint: disable=wrong-import-position
+    Base,
+    SessionLocal,
+    ShortLink,
+    SubdomainRedirect,
+    engine,
+)
+
+REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+@dataclass
+class _Headers:
+    _items: dict[str, str]
+
+    def __contains__(self, key: str) -> bool:  # pragma: no cover - helper
+        return key.lower() in self._items
+
+    def __getitem__(self, key: str) -> str:
+        return self._items[key.lower()]
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._items.get(key.lower(), default)
+
+    def items(self) -> Iterable[tuple[str, str]]:  # pragma: no cover - helper
+        return self._items.items()
+
+
+class SimpleResponse:
+    def __init__(self, status_code: int, headers: Iterable[tuple[str, str]], body: bytes) -> None:
+        self.status_code = status_code
+        self.headers = _Headers({k.lower(): v for k, v in headers})
+        self._body = body
+
+    def json(self) -> Any:
+        if not self._body:
+            return None
+        return json.loads(self._body.decode("utf-8"))
+
+    @property
+    def text(self) -> str:
+        return self._body.decode("utf-8")
+
+
+class SimpleClient:
+    def __init__(self) -> None:
+        self._app = app
+
+    def _run_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> SimpleResponse:
+        path, _, query = url.partition("?")
+        raw_path = path.encode("ascii", "ignore")
+        header_items = [
+            (key.encode("latin-1"), value.encode("latin-1"))
+            for key, value in headers.items()
+        ]
+
+        scope = {
+            "type": "http",
+            "http_version": "1.1",
+            "method": method.upper(),
+            "path": path,
+            "raw_path": raw_path,
+            "root_path": "",
+            "scheme": "http",
+            "query_string": query.encode("latin-1"),
+            "headers": header_items,
+            "client": ("testclient", 1234),
+            "server": (headers.get("host", "testserver"), 80),
+        }
+
+        messages: list[dict[str, Any]] = []
+        body_sent = False
+
+        async def receive() -> dict[str, Any]:
+            nonlocal body_sent
+            if body_sent:
+                return {"type": "http.disconnect"}
+            body_sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        async def send(message: dict[str, Any]) -> None:
+            messages.append(message)
+
+        asyncio.run(self._app(scope, receive, send))
+
+        status = 500
+        response_headers: list[tuple[str, str]] = []
+        chunks: list[bytes] = []
+        for message in messages:
+            if message["type"] == "http.response.start":
+                status = message["status"]
+                response_headers = [
+                    (key.decode("latin-1"), value.decode("latin-1"))
+                    for key, value in message.get("headers", [])
+                ]
+            elif message["type"] == "http.response.body":
+                chunks.append(message.get("body", b""))
+
+        return SimpleResponse(status, response_headers, b"".join(chunks))
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        json_body: Any | None = None,
+        auth: tuple[str, str] | None = None,
+        follow_redirects: bool = True,
+    ) -> SimpleResponse:
+        prepared_headers = {k.lower(): v for k, v in (headers or {}).items()}
+        prepared_headers.setdefault("host", "testserver")
+        body = b""
+        if json_body is not None:
+            body = json.dumps(json_body, ensure_ascii=False).encode("utf-8")
+            prepared_headers.setdefault("content-type", "application/json")
+
+        if auth is not None:
+            token = base64.b64encode(f"{auth[0]}:{auth[1]}".encode("utf-8")).decode("ascii")
+            prepared_headers["authorization"] = f"Basic {token}"
+
+        response = self._run_request(method, url, headers=prepared_headers, body=body)
+        if (
+            follow_redirects
+            and response.status_code in REDIRECT_STATUSES
+            and response.headers.get("location")
+        ):
+            location = response.headers["location"]
+            next_url = location
+            if location.startswith("http://") or location.startswith("https://"):
+                parts = location.split("://", 1)[1]
+                next_url = parts[parts.find("/") :] if "/" in parts else "/"
+            redirect_method = "GET" if response.status_code in {301, 302, 303} else method
+            return self.request(
+                redirect_method,
+                next_url,
+                headers=headers,
+                auth=auth,
+                follow_redirects=follow_redirects,
+            )
+        return response
+
+    def get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        auth: tuple[str, str] | None = None,
+        follow_redirects: bool = True,
+    ) -> SimpleResponse:
+        return self.request(
+            "GET",
+            url,
+            headers=headers,
+            auth=auth,
+            follow_redirects=follow_redirects,
+        )
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+        auth: tuple[str, str] | None = None,
+        follow_redirects: bool = True,
+    ) -> SimpleResponse:
+        return self.request(
+            "POST",
+            url,
+            headers=headers,
+            json_body=json,
+            auth=auth,
+            follow_redirects=follow_redirects,
+        )
+
+    def delete(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        auth: tuple[str, str] | None = None,
+        follow_redirects: bool = True,
+    ) -> SimpleResponse:
+        return self.request(
+            "DELETE",
+            url,
+            headers=headers,
+            auth=auth,
+            follow_redirects=follow_redirects,
+        )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prepare_database() -> None:
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+    if TEST_DB_PATH.exists():
+        TEST_DB_PATH.unlink()
+
+
+@pytest.fixture(autouse=True)
+def _clean_database() -> None:
+    with SessionLocal() as session:
+        session.execute(delete(ShortLink))
+        session.execute(delete(SubdomainRedirect))
+        session.commit()
+    yield
+    with SessionLocal() as session:
+        session.execute(delete(ShortLink))
+        session.execute(delete(SubdomainRedirect))
+        session.commit()
+
+
+@pytest.fixture()
+def client() -> SimpleClient:
+    return SimpleClient()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+def test_protected_endpoints_require_basic_auth(client: "SimpleClient") -> None:
+    response = client.get("/api/links")
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Basic"
+
+    response = client.post(
+        "/api/subdomains",
+        json={"host": "secure.test", "target_url": "https://example.com"},
+    )
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Basic"

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+ADMIN_AUTH = ("admin", "admin")
+
+
+def test_routes_endpoint_lists_subdomains(client: "SimpleClient") -> None:
+    client.post(
+        "/api/subdomains",
+        json={"host": "a.test", "target_url": "https://example.com/a"},
+        auth=ADMIN_AUTH,
+    )
+    client.post(
+        "/api/subdomains",
+        json={"host": "b.test", "target_url": "https://example.com/b"},
+        auth=ADMIN_AUTH,
+    )
+
+    response = client.get("/routes")
+    assert response.status_code == 200
+    hosts = [item["host"] for item in response.json()]
+    assert hosts == ["a.test", "b.test"]

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+ADMIN_AUTH = ("admin", "admin")
+
+
+def test_create_short_link(client: "SimpleClient") -> None:
+    response = client.post(
+        "/api/links",
+        json={"target_url": "https://example.com"},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["target_url"] == "https://example.com"
+    assert payload["code"]
+    assert payload["hits"] == 0
+
+
+def test_create_short_link_conflict(client: "SimpleClient") -> None:
+    client.post(
+        "/api/links",
+        json={"target_url": "https://example.com", "code": "custom"},
+        auth=ADMIN_AUTH,
+    )
+
+    conflict = client.post(
+        "/api/links",
+        json={"target_url": "https://example.org", "code": "custom"},
+        auth=ADMIN_AUTH,
+    )
+    assert conflict.status_code == 409
+    assert conflict.json() == {"error": "短链接编码已存在"}
+
+
+def test_redirect_short_link_and_hits(client: "SimpleClient") -> None:
+    client.post(
+        "/api/links",
+        json={"target_url": "https://example.com/landing", "code": "go"},
+        auth=ADMIN_AUTH,
+    )
+
+    redirect = client.get("/r/go", follow_redirects=False)
+    assert redirect.status_code == 302
+    assert redirect.headers["location"] == "https://example.com/landing"
+
+    listing = client.get("/api/links", auth=ADMIN_AUTH)
+    assert listing.status_code == 200
+    records = listing.json()
+    assert len(records) == 1
+    assert records[0]["hits"] == 1
+
+
+def test_redirect_short_link_not_found(client: "SimpleClient") -> None:
+    response = client.get("/r/missing", follow_redirects=False)
+    assert response.status_code == 404
+    assert response.json() == {"error": "短链接不存在"}

--- a/backend/tests/test_subdomains.py
+++ b/backend/tests/test_subdomains.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+ADMIN_AUTH = ("admin", "admin")
+
+
+def test_create_subdomain(client: "SimpleClient") -> None:
+    response = client.post(
+        "/api/subdomains",
+        json={"host": "docs.test", "target_url": "https://example.com/docs", "code": 301},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["host"] == "docs.test"
+    assert payload["target_url"] == "https://example.com/docs"
+    assert payload["code"] == 301
+
+
+def test_create_subdomain_conflict(client: "SimpleClient") -> None:
+    client.post(
+        "/api/subdomains",
+        json={"host": "api.test", "target_url": "https://example.com/api"},
+        auth=ADMIN_AUTH,
+    )
+
+    conflict = client.post(
+        "/api/subdomains",
+        json={"host": "api.test", "target_url": "https://example.org/api"},
+        auth=ADMIN_AUTH,
+    )
+    assert conflict.status_code == 409
+    assert conflict.json() == {"error": "子域跳转已存在"}
+
+
+def test_delete_subdomain(client: "SimpleClient") -> None:
+    created = client.post(
+        "/api/subdomains",
+        json={"host": "remove.test", "target_url": "https://example.com/remove"},
+        auth=ADMIN_AUTH,
+    ).json()
+
+    deleted = client.delete(f"/api/subdomains/{created['id']}", auth=ADMIN_AUTH)
+    assert deleted.status_code == 204
+
+    fallback = client.get("/", headers={"host": "remove.test"}, follow_redirects=False)
+    assert fallback.status_code == 404
+    assert fallback.text == "Not Found"
+
+
+def test_host_redirect_status_codes(client: "SimpleClient") -> None:
+    client.post(
+        "/api/subdomains",
+        json={"host": "legacy.test", "target_url": "https://legacy.example.com", "code": 301},
+        auth=ADMIN_AUTH,
+    )
+    client.post(
+        "/api/subdomains",
+        json={"host": "www.test", "target_url": "https://www.example.com"},
+        auth=ADMIN_AUTH,
+    )
+
+    permanent = client.get(
+        "/path", headers={"host": "legacy.test"}, follow_redirects=False
+    )
+    assert permanent.status_code == 301
+    assert permanent.headers["location"] == "https://legacy.example.com/path"
+
+    temporary = client.get(
+        "/docs?id=1", headers={"host": "www.test"}, follow_redirects=False
+    )
+    assert temporary.status_code == 302
+    assert (
+        temporary.headers["location"]
+        == "https://www.example.com/docs?id=1"
+    )
+
+
+def test_host_redirect_not_found(client: "SimpleClient") -> None:
+    response = client.get("/", headers={"host": "unknown.test"}, follow_redirects=False)
+    assert response.status_code == 404
+    assert response.text == "Not Found"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = backend/tests
+addopts = -q


### PR DESCRIPTION
## Summary
- add pytest configuration and extend backend dependencies for local testing
- build a lightweight ASGI client fixture so pytest can exercise FastAPI endpoints without httpx
- cover short link, subdomain redirect, authentication, and public route behaviours with dedicated pytest suites
- document the test workflow in the README for both local and Docker Compose environments

### Test Matrix
| 模块 | 场景 |
| --- | --- |
| 短链 | 创建成功 / 自定义编码冲突 409 / `/r/{code}` 302 跳转 / 未命中 404 / 命中次数累加 |
| 子域跳转 | 创建成功 / Host 冲突 409 / 删除成功 / Host 触发 301 与 302 / 未命中 404 |
| 认证 | `/api/*` 未携带 BasicAuth 返回 401 |
| 公共路由 | `/routes` 200 返回列表 |

## Testing
- `pytest -q` *(blocked: package installation requires external network access in this environment)*
- `docker compose exec backend pytest -q` *(blocked: docker is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df3f357e04832f84487a27ac42d74d