### PR TITLE
feat: add nginx upstream config for backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,8 @@
 - 为 FastAPI 应用实现短链接与子域 CRUD 接口，新增 HTTP Basic 认证保护 `/api/*` 与 `/admin`。
 - 增加 `/healthz`、`/r/{code}` 与 Host 通配跳转路由，未命中返回 404 文本。
 - README 增补接口表与 `curl` 示例，便于人工自测。
+
+## 2025-10-06
+- 新增 `infra/nginx/conf.d/yetla.upstream.conf`，将容器内 Nginx 的入口统一代理到 `backend`。
+- 提供 `docker-compose.override.yml`，默认保留 `8080:80` 并可选开启 `80:80` 暴露端口。
+- README 补充部署章节，说明容器化 Nginx → backend 的统一流量入口。

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ http://yet.la:8080          # 默认站点
 
 FastAPI 接口可通过 `http://localhost:8000/routes` 查看当前子域映射。
 
+## 部署
+
+默认的 `docker-compose.yml` 仍保留示例站点路由，方便验证静态 upstream 的写法。若要让容器化 Nginx 统一代理到 FastAPI backend，只需保留同目录下的 `docker-compose.override.yml`：
+
+- `infra/nginx/conf.d/yetla.upstream.conf`：监听 `yet.la` 与所有子域，将流量透传到 `backend:8000`，并传递 `Host`、`X-Forwarded-*` 等头部。
+- `docker-compose.override.yml`：在开发机同时暴露 `8080:80` 与可选的 `80:80`，并将上述配置挂载为 Nginx 的默认入口。
+
+运行 `docker compose up -d --build` 后，访问 `http://127.0.0.1:8080/`，即可通过后端提供的 `SubdomainRedirect` 数据命中 301/302 跳转。
+
 ## API 说明与示例 curl
 
 `backend/app/main.py` 提供了公开与受保护的接口组合：

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  nginx:
+    ports:
+      - "8080:80"
+      - "80:80"
+    volumes:
+      - ./infra/nginx/conf.d/yetla.upstream.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8080:80"
     volumes:
-      - ./infra/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./infra/nginx/conf.d/subdomains.conf:/etc/nginx/conf.d/default.conf:ro
       - ./apps/api:/usr/share/nginx/html/api:ro
       - ./apps/console:/usr/share/nginx/html/console:ro
       - ./apps/default:/usr/share/nginx/html:ro

--- a/infra/nginx/conf.d/yetla.upstream.conf
+++ b/infra/nginx/conf.d/yetla.upstream.conf
@@ -1,0 +1,15 @@
+# yet.la 生产入口，将所有请求转发到 backend 应用。
+server {
+    listen 80;
+    server_name yet.la *.yet.la;
+
+    location / {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+}


### PR DESCRIPTION
## Summary
- add a production nginx server block that forwards yet.la traffic to the backend container
- ship a docker compose override to mount the new config and optionally expose port 80
- document the container nginx to backend flow and record the change in the changelog

## Testing
- ⚠️ `docker compose up -d --build` *(not run: docker CLI unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df415efb6c832f8b5a4b9796cff1e6