### PR TITLE
Add compose healthcheck and Makefile shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,8 @@
 - 新增 `infra/nginx/conf.d/yetla.upstream.conf`，将容器内 Nginx 的入口统一代理到 `backend`。
 - 提供 `docker-compose.override.yml`，默认保留 `8080:80` 并可选开启 `80:80` 暴露端口。
 - README 补充部署章节，说明容器化 Nginx → backend 的统一流量入口。
+
+## 2025-10-07
+- 为 backend 服务新增 Docker Compose 健康检查，命中 `/routes` 确认数据接口可用。
+- 在仓库根目录加入 `Makefile`，封装 `up/down/logs/test/shell` 常用命令。
+- README 新增「一键命令」章节，介绍上述快捷指令。

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+COMPOSE = docker compose -f docker-compose.yml -f docker-compose.override.yml
+
+.PHONY: up down logs test shell
+
+up:
+	$(COMPOSE) up -d --build
+
+down:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f
+
+test:
+	$(COMPOSE) run --rm backend pytest -q
+
+shell:
+	$(COMPOSE) run --rm backend bash

--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ http://yet.la:8080          # 默认站点
 
 FastAPI 接口可通过 `http://localhost:8000/routes` 查看当前子域映射。
 
+## 一键命令
+
+项目根目录提供了 `Makefile`，将常用的 Docker Compose 操作封装为以下指令：
+
+```bash
+# 构建并启动所有服务（等价于 docker compose up -d --build）
+make up
+
+# 停止并清理容器、网络与匿名卷
+make down
+
+# 追踪所有服务的输出日志
+make logs
+
+# 在后端容器内运行 Pytest 用例
+make test
+
+# 启动后端容器的交互式 Shell
+make shell
+```
+
+上述命令默认读取 `docker-compose.yml` 与 `docker-compose.override.yml`，方便在开发机快速验证路由配置与接口健康状况。
+
 ## 部署
 
 默认的 `docker-compose.yml` 仍保留示例站点路由，方便验证静态 upstream 的写法。若要让容器化 Nginx 统一代理到 FastAPI backend，只需保留同目录下的 `docker-compose.override.yml`：

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,3 +7,11 @@ services:
       - "80:80"
     volumes:
       - ./infra/nginx/conf.d/yetla.upstream.conf:/etc/nginx/conf.d/default.conf:ro
+
+  backend:
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/routes')"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s


### PR DESCRIPTION
## Summary
- add a docker compose healthcheck override for the backend that checks `/routes`
- introduce a Makefile with up/down/logs/test/shell shortcuts and document the commands in the README
- extend the changelog with the latest operational updates

## Testing
- make test *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df4b02b1a0832f9b41e607f6503289