### PR TITLE
docs: document security baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+data/
+.env

--- a/docs/backup-example.sh
+++ b/docs/backup-example.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 示例备份脚本：供 cron 调度使用，将 yet.la 数据与日志归档后上传到远端存储。
+# 根据生产环境修改 STORAGE_CMD 以适配 rsync、rclone 或云厂商 CLI。
+
+set -euo pipefail
+
+YETLA_ROOT="/opt/yetla"
+BACKUP_ROOT="/var/backups/yetla"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+ARCHIVE_PATH="$BACKUP_ROOT/yetla-${TIMESTAMP}.tar.gz"
+RETENTION_DAYS=7
+
+mkdir -p "$BACKUP_ROOT"
+
+# 打包数据卷与应用日志，可按需扩展包含更多目录。
+tar -czf "$ARCHIVE_PATH" \
+  -C "$YETLA_ROOT" data \
+  -C "$YETLA_ROOT" logs || { rm -f "$ARCHIVE_PATH"; exit 1; }
+
+# 将归档同步到远端目标（示例：挂载的对象存储或备份服务器）。
+STORAGE_CMD=(rsync -av "$ARCHIVE_PATH" backup@example.com:/srv/backups/yetla/)
+"${STORAGE_CMD[@]}"
+
+# 删除过期备份，保留最近 RETENTION_DAYS 天。
+find "$BACKUP_ROOT" -name 'yetla-*.tar.gz' -mtime +$((RETENTION_DAYS - 1)) -delete


### PR DESCRIPTION
## Summary
- 建议：在 README 中新增安全基线章节，覆盖强口令要求、管理接口 IP 白名单示例与定时备份策略。
- 建议：提供 cron 任务示例与可复用的 `docs/backup-example.sh` 脚本，帮助落地日志与数据备份。
- 建议：更新 `.gitignore` 忽略 `data/` 与 `.env`，降低误提交风险。

## Risk Boundaries
- 文档示例未自动强化现有部署，仍需依据实际环境审查与调整。

## Testing
- Not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68df4d80e9dc832fa8277e27e8357587