### PR TITLE
Improve deployment docs and backend setup

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for the yet.la management platform."""

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pydantic==2.6.4
 sqlalchemy==2.0.29
 pytest==8.1.1
 httpx==0.27.0
+python-multipart==0.0.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,5 @@ services:
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     volumes:
       - ./data:/data
+    env_file:
+      - ./.env

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = backend/tests
 addopts = -q
+pythonpath = .

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Bootstrap script for a fresh Ubuntu 22.04 VPS to run yet.la stack.
+set -euo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+  echo "[错误] 请以 root 或使用 sudo 运行本脚本" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y ca-certificates curl gnupg lsb-release git make
+
+install -m 0755 -d /etc/apt/keyrings
+if [[ ! -f /etc/apt/keyrings/docker.gpg ]]; then
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+fi
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+# 添加 Docker 官方软件源
+. /etc/os-release
+cat <<REPO >/etc/apt/sources.list.d/docker.list
+deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+  https://download.docker.com/linux/ubuntu \
+  ${VERSION_CODENAME} stable
+REPO
+
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable --now docker
+
+if systemctl is-active --quiet docker; then
+  echo "[信息] Docker 服务已启动"
+else
+  echo "[警告] Docker 服务未正常启动，请检查 systemctl status docker" >&2
+fi
+
+# 将当前 sudo 用户加入 docker 组，方便无 sudo 运行 docker 命令
+if [[ -n "${SUDO_USER:-}" ]]; then
+  usermod -aG docker "${SUDO_USER}"
+  target_user="${SUDO_USER}"
+elif [[ -n "${TARGET_USER:-}" ]]; then
+  usermod -aG docker "${TARGET_USER}"
+  target_user="${TARGET_USER}"
+else
+  target_user=""
+fi
+
+cat <<INFO
+
+依赖安装完成：
+  - $(docker --version)
+  - $(docker compose version)
+
+若刚将用户添加到 docker 组，请重新登录终端后再执行 docker 命令。
+INFO
+
+if [[ -n "${target_user}" ]]; then
+  echo "[提示] 用户 ${target_user} 已加入 docker 组。若为当前会话，请执行 \"newgrp docker\" 或重新登录。"
+fi


### PR DESCRIPTION
## Summary
- add an Ubuntu 22.04 bootstrap script and expand the README with end-to-end deployment guidance
- load the project .env into the backend container and document that FastAPI docs endpoints are disabled by default
- harden form parsing and authentication error handling in the FastAPI app while keeping catch-all redirects working without python-multipart installed

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68dfb822c45c832f8a73b50efbfc8b98