### PR TITLE
Ensure /data initialization and remove redundant nginx mounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ $ bash scripts/smoke.sh
      chmod 700 data
      ```
 
-   - 如果需要让容器化 Nginx 统一代理到 FastAPI，可保留 `docker-compose.override.yml` 以及 `infra/nginx/conf.d/yetla.upstream.conf`，其中已内置监听 `yet.la` 与所有子域的示例配置。
+  - Nginx 默认使用 `infra/nginx/conf.d/subdomains.conf`，无需再挂载 `apps/api`、`apps/console` 等静态目录。
+  - 如果需要让容器化 Nginx 统一代理到 FastAPI，可保留 `docker-compose.override.yml` 以及 `infra/nginx/conf.d/yetla.upstream.conf`，其中已内置监听 `yet.la` 与所有子域的示例配置。
    - 在生产环境中，可根据实际域名与证书路径调整 `infra/nginx` 下的配置文件，然后通过挂载覆盖默认配置。
 
 5. **启动服务**

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import os
 import secrets
 import string
 
+from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl
 
@@ -42,7 +43,12 @@ app.include_router(admin_router, dependencies=[Depends(require_basic_auth)])
 
 @app.on_event("startup")
 def ensure_tables() -> None:
-    """应用启动时自动创建数据库表。"""
+    """应用启动时确保数据目录存在并创建数据库表。"""
+
+    try:
+        Path("/data").mkdir(parents=True, exist_ok=True)
+    except Exception as exc:  # pragma: no cover - 失败属于部署问题
+        raise RuntimeError(f"failed to ensure /data directory: {exc}") from exc
 
     Base.metadata.create_all(bind=engine)
 

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -2,6 +2,10 @@
 
 {% block content %}
 <div class="space-y-8">
+  <div class="rounded-md border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-700">
+    管理后台的所有表单均直接调用 <code class="font-mono">/api/*</code> 接口，请按接口契约填写字段；
+    若提交失败将展示后端返回的原始错误信息，便于排查。
+  </div>
   <section class="rounded-lg border border-slate-200 bg-white shadow-sm">
     <nav class="border-b border-slate-200 px-6 pt-6" aria-label="Sections">
       <ul class="flex flex-wrap gap-3 text-sm font-medium text-slate-500">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,25 +7,9 @@ services:
       - "8080:80"
     volumes:
       - ./infra/nginx/conf.d/subdomains.conf:/etc/nginx/conf.d/default.conf:ro
-    depends_on:
-      - app_api
-      - app_console
-      - app_default
-
-  app_api:
-    image: nginx:1.25-alpine
-    volumes:
-      - ./apps/api:/usr/share/nginx/html:ro
-
-  app_console:
-    image: nginx:1.25-alpine
-    volumes:
-      - ./apps/console:/usr/share/nginx/html:ro
-
-  app_default:
-    image: nginx:1.25-alpine
-    volumes:
       - ./apps/default:/usr/share/nginx/html:ro
+    depends_on:
+      - backend
 
   backend:
     build:


### PR DESCRIPTION
## Summary
- ensure the backend creates /data on startup before initializing the database schema
- add an admin UI notice that clarifies form submissions hit the same /api endpoints
- simplify the nginx service to drop redundant static mounts and document the upstream setup

## Testing
- pytest -q
- BASE_URL=http://127.0.0.1:8000 ADMIN_USER=admin ADMIN_PASS=admin bash scripts/smoke.sh *(fails: backend not running in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dfd046a65c832fb17a0cb01023c2b3