### PR TITLE
Restore HTTPS port mapping in docker-compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,6 +4,7 @@ services:
   nginx:
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./infra/nginx/conf.d/yetla.upstream.conf:/etc/nginx/conf.d/default.conf:ro
 


### PR DESCRIPTION
## Summary
- expose the nginx 443 port mapping in docker-compose.override.yml so HTTPS stays reachable when the override file is used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dfe20e62dc832fa97111237bf00b4c