### PR TITLE
Improve nginx certificate bootstrap for nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,12 @@ services:
       - ./infra/nginx/docker-entrypoint.d:/docker-entrypoint.d:ro
       - type: bind
         source: /root/ssl
-        target: /etc/nginx/ssl
+        target: /etc/nginx/ssl-src
         read_only: true
+      - nginx_ssl_cache:/etc/nginx/ssl
+    environment:
+      - SSL_SOURCE_DIR=/etc/nginx/ssl-src
+      - SSL_TARGET_DIR=/etc/nginx/ssl
     depends_on:
       - backend
 
@@ -27,3 +31,6 @@ services:
       - ./data:/data
     env_file:
       - ./.env
+
+volumes:
+  nginx_ssl_cache:

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -6,4 +6,5 @@
 2. Nginx 根据请求头中的 `Host` 字段选择不同的 upstream，达到“子域内部分流”的目的。
 3. 当需要新增子域时，只需更新 map 表并重载 Nginx，无需再修改 DNS。
 
-`subdomains.conf` 展示了 map 与 upstream 的基础写法，同时保留了未匹配子域的兜底策略。
+`subdomains.conf` 展示了 map 与 upstream 的基础写法，同时保留了未匹配子域的兜底策略。生产环境中，入口脚本会从 `/etc/nginx/ssl-src`
+解析真实证书并在 `/etc/nginx/ssl` 内生成标准化链接，便于直接复用 `ssl_certificate` 与 `ssl_certificate_key` 配置。

--- a/infra/nginx/docker-entrypoint.d/10-setup-cert-links.sh
+++ b/infra/nginx/docker-entrypoint.d/10-setup-cert-links.sh
@@ -1,39 +1,95 @@
 #!/bin/sh
 set -eu
 
-CERT_ROOT="/etc/nginx/ssl"
-FULLCHAIN="$CERT_ROOT/fullchain.cer"
-PRIVATE_KEY="$CERT_ROOT/private.key"
+TARGET_ROOT="${SSL_TARGET_DIR:-/etc/nginx/ssl}"
+SOURCE_ROOT="${SSL_SOURCE_DIR:-$TARGET_ROOT}"
+FULLCHAIN="$TARGET_ROOT/fullchain.cer"
+PRIVATE_KEY="$TARGET_ROOT/private.key"
+
+ensure_target_dir() {
+    if [ -d "$TARGET_ROOT" ]; then
+        return
+    fi
+
+    if ! mkdir -p "$TARGET_ROOT" 2>/dev/null; then
+        echo "[entrypoint] 无法创建证书目录: $TARGET_ROOT" >&2
+        exit 1
+    fi
+}
+
+find_cert_files() {
+    directory="$1"
+
+    if [ ! -d "$directory" ]; then
+        return
+    fi
+
+    fullchain=""
+    private=""
+
+    for name in fullchain.cer fullchain.pem cert.pem certificate.pem; do
+        candidate="$directory/$name"
+        if [ -f "$candidate" ]; then
+            fullchain="$candidate"
+            break
+        fi
+    done
+
+    for name in private.key privkey.pem privkey.key key.pem; do
+        candidate="$directory/$name"
+        if [ -f "$candidate" ]; then
+            private="$candidate"
+            break
+        fi
+    done
+
+    if [ -n "$fullchain" ] && [ -n "$private" ]; then
+        echo "$fullchain|$private"
+    fi
+}
+
+link_certificates() {
+    source_fullchain="$1"
+    source_private="$2"
+
+    if [ ! -w "$TARGET_ROOT" ]; then
+        echo "[entrypoint] 证书目录不可写: $TARGET_ROOT" >&2
+        echo "[entrypoint] 请在宿主机创建 fullchain.cer 与 private.key，或放宽挂载权限" >&2
+        exit 1
+    fi
+
+    ln -sf "$source_fullchain" "$FULLCHAIN"
+    ln -sf "$source_private" "$PRIVATE_KEY"
+    echo "[entrypoint] 已链接证书: $FULLCHAIN -> $source_fullchain" >&2
+    echo "[entrypoint] 已链接私钥: $PRIVATE_KEY -> $source_private" >&2
+    exit 0
+}
+
+ensure_target_dir
 
 if [ -f "$FULLCHAIN" ] && [ -f "$PRIVATE_KEY" ]; then
-    echo "[entrypoint] 证书文件已就绪: $CERT_ROOT" >&2
+    echo "[entrypoint] 证书文件已就绪: $TARGET_ROOT" >&2
     exit 0
 fi
 
-for candidate in "$CERT_ROOT"/*.yet.la_yet.la_P256; do
-    if [ ! -d "$candidate" ]; then
-        continue
-    fi
-
-    candidate_fullchain="$candidate/fullchain.cer"
-    candidate_private="$candidate/private.key"
-
-    if [ ! -f "$candidate_fullchain" ] || [ ! -f "$candidate_private" ]; then
-        echo "[entrypoint] 证书目录存在但文件缺失: $candidate" >&2
-        continue
-    fi
-
-    if [ -w "$CERT_ROOT" ]; then
-        ln -sf "$candidate_fullchain" "$FULLCHAIN"
-        ln -sf "$candidate_private" "$PRIVATE_KEY"
-        echo "[entrypoint] 已将证书标准化为 $CERT_ROOT/{fullchain.cer,private.key}" >&2
-        exit 0
-    fi
-
-    echo "[entrypoint] 检测到只读挂载: $CERT_ROOT" >&2
-    echo "[entrypoint] 请在宿主机创建指向 $candidate 的符号链接 fullchain.cer/private.key" >&2
+if [ ! -d "$SOURCE_ROOT" ]; then
+    echo "[entrypoint] 证书源目录不存在: $SOURCE_ROOT" >&2
     exit 1
+fi
+
+# 首先检查源目录根路径
+candidate_pair="$(find_cert_files "$SOURCE_ROOT")"
+if [ -n "$candidate_pair" ]; then
+    link_certificates "${candidate_pair%|*}" "${candidate_pair#*|}"
+fi
+
+# 遍历源目录下的子目录，寻找常见的证书文件命名方式
+for candidate_dir in "$SOURCE_ROOT"/*; do
+    candidate_pair="$(find_cert_files "$candidate_dir")"
+    if [ -n "$candidate_pair" ]; then
+        link_certificates "${candidate_pair%|*}" "${candidate_pair#*|}"
+    fi
 done
 
-echo "[entrypoint] 未找到 TLS 证书，请确认 /root/ssl 已提供 fullchain.cer 与 private.key" >&2
+echo "[entrypoint] 未找到 TLS 证书，请确认 $SOURCE_ROOT 下存在 fullchain/private 文件" >&2
 exit 1


### PR DESCRIPTION
## Summary
- allow the nginx entrypoint to locate common certificate layouts and link them into a writable cache directory
- mount the host TLS directory read-only as a source and document the updated bootstrap process in the README files

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_b_68dfe323c880832f9eaa1436c2847d6f