### PR TITLE
Fix HTMX admin requests missing credentials

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -18,7 +18,12 @@
     ></script>
     <script>
       document.addEventListener("htmx:configRequest", function (event) {
-        event.detail.withCredentials = true;
+        if (event.detail.xhr) {
+          event.detail.xhr.withCredentials = true;
+        }
+        if (event.detail.fetchOpts) {
+          event.detail.fetchOpts.credentials = "include";
+        }
       });
     </script>
   </head>


### PR DESCRIPTION
## Summary
- ensure the admin dashboard HTMX requests forward credentials whether they use XHR or fetch

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_b_68dfeab46278832fa85c4b59ad899360