### PR TITLE
Ensure admin forms submit to API endpoints

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -54,6 +54,8 @@
           </div>
           <form
             class="space-y-4 px-6 py-6"
+            action="/api/links"
+            method="post"
             hx-post="/api/links"
             hx-trigger="submit"
             hx-target="#link-feedback"
@@ -131,6 +133,8 @@
           </div>
           <form
             class="space-y-4 px-6 py-6"
+            action="/api/subdomains"
+            method="post"
             hx-post="/api/subdomains"
             hx-trigger="submit"
             hx-target="#subdomain-feedback"


### PR DESCRIPTION
## Summary
- ensure the admin short-link form explicitly posts to the protected API endpoint
- ensure the admin subdomain form also degrades to the API endpoint when JavaScript is unavailable

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dff13b19b4832fb8d6067e499d5972