### PR TITLE
Add inline editing for short links and subdomains

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -35,6 +35,10 @@ class SubdomainRedirectCreate(SubdomainRedirectBase):
     pass
 
 
+class SubdomainRedirectUpdate(SubdomainRedirectBase):
+    pass
+
+
 class ShortLinkBase(BaseModel):
     target_url: str = Field(..., description="目标地址")
 
@@ -58,4 +62,16 @@ class ShortLink(ShortLinkBase):
     created_at: datetime = Field(..., description="创建时间")
 
     model_config = {"from_attributes": True}
+
+
+class ShortLinkUpdate(ShortLinkBase):
+    code: str = Field(..., description="短链编码")
+
+    @field_validator("code")
+    @classmethod
+    def _normalize_code(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("短链编码不能为空")
+        return stripped
 

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -60,7 +60,7 @@
             hx-trigger="submit"
             hx-target="#link-feedback"
             hx-swap="innerHTML"
-            hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-links') }"
+            hx-on::afterRequest="if(event.detail.successful){ this.reset(); htmx.trigger(document.body, 'refresh-links') }"
           >
             <div class="grid gap-4 sm:grid-cols-2">
               <div>
@@ -139,7 +139,7 @@
             hx-trigger="submit"
             hx-target="#subdomain-feedback"
             hx-swap="innerHTML"
-            hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-subdomains') }"
+            hx-on::afterRequest="if(event.detail.successful){ this.reset(); htmx.trigger(document.body, 'refresh-subdomains') }"
           >
             <div class="grid gap-4 sm:grid-cols-2">
               <div>

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -1,0 +1,56 @@
+<tr class="bg-slate-50">
+  <td colspan="5" class="px-4 py-4">
+    <form
+      class="space-y-4"
+      hx-put="/api/links/{{ item.id }}"
+      hx-target="#link-feedback"
+      hx-swap="innerHTML"
+      hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-links') }"
+    >
+      <div class="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label for="code-{{ item.id }}" class="block text-xs font-medium text-slate-600">短链编码</label>
+          <input
+            id="code-{{ item.id }}"
+            name="code"
+            type="text"
+            required
+            value="{{ item.code }}"
+            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+          />
+        </div>
+        <div class="sm:col-span-2">
+          <label for="target-{{ item.id }}" class="block text-xs font-medium text-slate-600">目标地址</label>
+          <input
+            id="target-{{ item.id }}"
+            name="target_url"
+            type="url"
+            required
+            value="{{ item.target_url }}"
+            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+          />
+        </div>
+      </div>
+      <div class="flex items-center justify-between">
+        <p class="text-xs text-slate-500">提交后会立即更新短链并刷新列表。</p>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+            hx-get="/admin/links/{{ item.id }}/row"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+          >
+            取消
+          </button>
+          <button
+            type="submit"
+            class="inline-flex items-center rounded-md bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-sky-500"
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </form>
+  </td>
+</tr>

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -1,0 +1,32 @@
+<tr class="hover:bg-slate-50">
+  <td class="px-4 py-3 font-mono text-slate-800">{{ item.code }}</td>
+  <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
+  <td class="px-4 py-3 text-slate-600">{{ item.hits }}</td>
+  <td class="px-4 py-3 text-slate-500">
+    {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+  </td>
+  <td class="px-4 py-3">
+    <div class="flex justify-end gap-2">
+      <button
+        type="button"
+        class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+        hx-get="/admin/links/{{ item.id }}/edit"
+        hx-target="closest tr"
+        hx-swap="outerHTML"
+      >
+        编辑
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-600 shadow-sm transition hover:bg-rose-50"
+        hx-delete="/api/links/{{ item.id }}"
+        hx-target="#link-feedback"
+        hx-swap="innerHTML"
+        hx-confirm="确认删除该短链？"
+        hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-links') }"
+      >
+        删除
+      </button>
+    </div>
+  </td>
+</tr>

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -11,29 +11,7 @@
   </thead>
   <tbody class="divide-y divide-slate-100">
     {% for item in short_links %}
-    <tr class="hover:bg-slate-50">
-      <td class="px-4 py-3 font-mono text-slate-800">{{ item.code }}</td>
-      <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
-      <td class="px-4 py-3 text-slate-600">{{ item.hits }}</td>
-      <td class="px-4 py-3 text-slate-500">
-        {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
-      </td>
-      <td class="px-4 py-3">
-        <div class="flex justify-end">
-          <button
-            type="button"
-            class="inline-flex items-center rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-600 shadow-sm transition hover:bg-rose-50"
-            hx-delete="/api/links/{{ item.id }}"
-            hx-target="#link-feedback"
-            hx-swap="innerHTML"
-            hx-confirm="确认删除该短链？"
-            hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-links') }"
-          >
-            删除
-          </button>
-        </div>
-      </td>
-    </tr>
+    {% include "admin/partials/link_row.html" %}
     {% endfor %}
   </tbody>
 </table>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -1,0 +1,70 @@
+<tr class="bg-slate-50">
+  <td colspan="5" class="px-4 py-4">
+    <form
+      class="space-y-4"
+      hx-put="/api/subdomains/{{ item.id }}"
+      hx-target="#subdomain-feedback"
+      hx-swap="innerHTML"
+      hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-subdomains') }"
+    >
+      <div class="grid gap-4 sm:grid-cols-3">
+        <div class="sm:col-span-1">
+          <label for="host-{{ item.id }}" class="block text-xs font-medium text-slate-600">Host</label>
+          <input
+            id="host-{{ item.id }}"
+            name="host"
+            type="text"
+            required
+            value="{{ item.host }}"
+            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+          />
+        </div>
+        <div>
+          <label for="code-{{ item.id }}" class="block text-xs font-medium text-slate-600">状态码</label>
+          <input
+            id="code-{{ item.id }}"
+            name="code"
+            type="number"
+            min="301"
+            max="302"
+            step="1"
+            required
+            value="{{ item.code }}"
+            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+          />
+        </div>
+        <div class="sm:col-span-3">
+          <label for="target-{{ item.id }}" class="block text-xs font-medium text-slate-600">目标地址</label>
+          <input
+            id="target-{{ item.id }}"
+            name="target_url"
+            type="url"
+            required
+            value="{{ item.target_url }}"
+            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+          />
+        </div>
+      </div>
+      <div class="flex items-center justify-between">
+        <p class="text-xs text-slate-500">更新后会覆盖现有跳转配置并刷新列表。</p>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+            hx-get="/admin/subdomains/{{ item.id }}/row"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+          >
+            取消
+          </button>
+          <button
+            type="submit"
+            class="inline-flex items-center rounded-md bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-sky-500"
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </form>
+  </td>
+</tr>

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -1,0 +1,32 @@
+<tr class="hover:bg-slate-50">
+  <td class="px-4 py-3 font-mono text-slate-800">{{ item.host }}</td>
+  <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
+  <td class="px-4 py-3 text-slate-600">{{ item.code }}</td>
+  <td class="px-4 py-3 text-slate-500">
+    {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+  </td>
+  <td class="px-4 py-3">
+    <div class="flex justify-end gap-2">
+      <button
+        type="button"
+        class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+        hx-get="/admin/subdomains/{{ item.id }}/edit"
+        hx-target="closest tr"
+        hx-swap="outerHTML"
+      >
+        编辑
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-600 shadow-sm transition hover:bg-rose-50"
+        hx-delete="/api/subdomains/{{ item.id }}"
+        hx-target="#subdomain-feedback"
+        hx-swap="innerHTML"
+        hx-confirm="确认删除该子域跳转？"
+        hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-subdomains') }"
+      >
+        删除
+      </button>
+    </div>
+  </td>
+</tr>

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -11,29 +11,7 @@
   </thead>
   <tbody class="divide-y divide-slate-100">
     {% for item in subdomains %}
-    <tr class="hover:bg-slate-50">
-      <td class="px-4 py-3 font-mono text-slate-800">{{ item.host }}</td>
-      <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
-      <td class="px-4 py-3 text-slate-600">{{ item.code }}</td>
-      <td class="px-4 py-3 text-slate-500">
-        {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
-      </td>
-      <td class="px-4 py-3">
-        <div class="flex justify-end">
-          <button
-            type="button"
-            class="inline-flex items-center rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-600 shadow-sm transition hover:bg-rose-50"
-            hx-delete="/api/subdomains/{{ item.id }}"
-            hx-target="#subdomain-feedback"
-            hx-swap="innerHTML"
-            hx-confirm="确认删除该子域跳转？"
-            hx-on::afterRequest="if(event.detail.successful){ htmx.trigger(document.body, 'refresh-subdomains') }"
-          >
-            删除
-          </button>
-        </div>
-      </td>
-    </tr>
+    {% include "admin/partials/subdomain_row.html" %}
     {% endfor %}
   </tbody>
 </table>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import select
@@ -81,6 +81,42 @@ def short_link_table(
     )
 
 
+@router.get("/admin/links/{link_id}/row", response_class=HTMLResponse)
+def short_link_row(
+    request: Request,
+    link_id: int,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """Return a single short link row for cancel/edit swaps."""
+
+    short_link = db.get(ShortLink, link_id)
+    if short_link is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="短链接不存在")
+
+    return templates.TemplateResponse(
+        "admin/partials/link_row.html",
+        {"request": request, "item": short_link},
+    )
+
+
+@router.get("/admin/links/{link_id}/edit", response_class=HTMLResponse)
+def short_link_edit_row(
+    request: Request,
+    link_id: int,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """Return the editable row for a specific short link."""
+
+    short_link = db.get(ShortLink, link_id)
+    if short_link is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="短链接不存在")
+
+    return templates.TemplateResponse(
+        "admin/partials/link_edit_row.html",
+        {"request": request, "item": short_link},
+    )
+
+
 @router.get("/admin/subdomains/count", response_class=HTMLResponse)
 def subdomain_count(
     request: Request,
@@ -106,4 +142,40 @@ def subdomain_table(
     return templates.TemplateResponse(
         "admin/partials/subdomain_table.html",
         {"request": request, "subdomains": subdomains},
+    )
+
+
+@router.get("/admin/subdomains/{redirect_id}/row", response_class=HTMLResponse)
+def subdomain_row(
+    request: Request,
+    redirect_id: int,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """Return a single subdomain redirect row."""
+
+    redirect = db.get(SubdomainRedirect, redirect_id)
+    if redirect is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="子域跳转不存在")
+
+    return templates.TemplateResponse(
+        "admin/partials/subdomain_row.html",
+        {"request": request, "item": redirect},
+    )
+
+
+@router.get("/admin/subdomains/{redirect_id}/edit", response_class=HTMLResponse)
+def subdomain_edit_row(
+    request: Request,
+    redirect_id: int,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """Return the editable row for a subdomain redirect."""
+
+    redirect = db.get(SubdomainRedirect, redirect_id)
+    if redirect is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="子域跳转不存在")
+
+    return templates.TemplateResponse(
+        "admin/partials/subdomain_edit_row.html",
+        {"request": request, "item": redirect},
     )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -211,6 +211,26 @@ class SimpleClient:
             follow_redirects=follow_redirects,
         )
 
+    def put(
+        self,
+        url: str,
+        *,
+        json: Any | None = None,
+        data: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+        auth: tuple[str, str] | None = None,
+        follow_redirects: bool = True,
+    ) -> SimpleResponse:
+        return self.request(
+            "PUT",
+            url,
+            headers=headers,
+            json_body=json,
+            data=data,
+            auth=auth,
+            follow_redirects=follow_redirects,
+        )
+
     def delete(
         self,
         url: str,


### PR DESCRIPTION
## Summary
- add PUT endpoints and schemas so short links and subdomains can be updated with HTMX responses
- refresh the admin dashboard to support inline edit rows, reset creation forms, and keep delete feedback working
- extend the test client plus API suites to cover HTMX update flows for both resources

## Testing
- pytest backend/tests/test_short_links.py backend/tests/test_subdomains.py

------
https://chatgpt.com/codex/tasks/task_b_68dff30676c0832f84640fb0ca1b6899