### PR TITLE
Improve admin inline edit UX with OOB updates

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,7 +41,10 @@ app = FastAPI(
 )
 
 
-from .views import router as admin_router  # noqa: E402  pylint: disable=wrong-import-position
+from .views import (
+    router as admin_router,
+    templates as admin_templates,
+)  # noqa: E402  pylint: disable=wrong-import-position
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
@@ -407,8 +410,12 @@ async def update_short_link(
             "短链已更新"
             "</div>"
         )
+        row_html = admin_templates.get_template("admin/partials/link_row.html").render(
+            {"request": request, "item": short_link, "oob": True}
+        )
+        content = f"{message}{row_html}"
         return HTMLResponse(
-            message,
+            content,
             status_code=status.HTTP_200_OK,
             headers={"HX-Trigger": "refresh-links"},
         )
@@ -546,8 +553,12 @@ async def update_subdomain(
             "子域跳转已更新"
             "</div>"
         )
+        row_html = admin_templates.get_template("admin/partials/subdomain_row.html").render(
+            {"request": request, "item": redirect, "oob": True}
+        )
+        content = f"{message}{row_html}"
         return HTMLResponse(
-            message,
+            content,
             status_code=status.HTTP_200_OK,
             headers={"HX-Trigger": "refresh-subdomains"},
         )

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -1,4 +1,4 @@
-<tr class="bg-slate-50">
+<tr id="short-link-row-{{ item.id }}" class="bg-slate-50">
   <td colspan="5" class="px-4 py-4">
     <form
       class="space-y-4"

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -1,4 +1,8 @@
-<tr class="hover:bg-slate-50">
+<tr
+  id="short-link-row-{{ item.id }}"
+  class="hover:bg-slate-50"
+  {% if oob %}hx-swap-oob="outerHTML"{% endif %}
+>
   <td class="px-4 py-3 font-mono text-slate-800">{{ item.code }}</td>
   <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
   <td class="px-4 py-3 text-slate-600">{{ item.hits }}</td>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -1,4 +1,4 @@
-<tr class="bg-slate-50">
+<tr id="subdomain-row-{{ item.id }}" class="bg-slate-50">
   <td colspan="6" class="px-4 py-4">
     <form
       class="space-y-4"

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -1,4 +1,8 @@
-<tr class="hover:bg-slate-50">
+<tr
+  id="subdomain-row-{{ item.id }}"
+  class="hover:bg-slate-50"
+  {% if oob %}hx-swap-oob="outerHTML"{% endif %}
+>
   <td class="px-4 py-3 font-mono text-slate-800">{{ item.host }}</td>
   <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
   <td class="px-4 py-3 text-slate-600">{{ item.code }}</td>

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -102,6 +102,8 @@ def test_update_short_link_via_htmx_form(client: "SimpleClient") -> None:
     assert response.status_code == 200
     assert response.headers.get("hx-trigger") == "refresh-links"
     assert "短链已更新" in response.text
+    assert "short-link-row" in response.text
+    assert "hx-swap-oob=\"outerHTML\"" in response.text
 
     listing = client.get("/api/links", auth=ADMIN_AUTH)
     records = listing.json()

--- a/backend/tests/test_subdomains.py
+++ b/backend/tests/test_subdomains.py
@@ -64,6 +64,8 @@ def test_update_subdomain_via_htmx_form(client: "SimpleClient") -> None:
     assert response.status_code == 200
     assert response.headers.get("hx-trigger") == "refresh-subdomains"
     assert "子域跳转已更新" in response.text
+    assert "subdomain-row" in response.text
+    assert "hx-swap-oob=\"outerHTML\"" in response.text
 
     listing = client.get("/api/subdomains", auth=ADMIN_AUTH)
     records = listing.json()


### PR DESCRIPTION
## Summary
- ensure inline edit rows expose stable ids so htmx can target them for out-of-band swaps
- return updated row markup alongside success messages so inline edits immediately refresh in the admin tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dffff6ab08832f929f2ab4a29d48cb