### PR TITLE
Fix admin fallback fetch on credentialed URLs

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -65,8 +65,26 @@
     return Object.assign(headers, extra || {});
   }
 
+  function toAbsoluteUrl(url) {
+    if (!url) {
+      return url;
+    }
+
+    try {
+      const base = `${window.location.protocol}//${window.location.host}`;
+      return new URL(url, base).toString();
+    } catch (error) {
+      console.warn("Failed to construct absolute URL", url, error);
+      return url;
+    }
+  }
+
   async function fetchFragment(url, options) {
-    const response = await fetch(url, Object.assign({ credentials: "include" }, options));
+    const absoluteUrl = toAbsoluteUrl(url);
+    const response = await fetch(
+      absoluteUrl,
+      Object.assign({ credentials: "include" }, options),
+    );
     const text = await response.text();
     return { response, text };
   }


### PR DESCRIPTION
## Summary
- add a helper to normalize fallback request URLs against the current origin
- update all admin dashboard fallback fetches to avoid credentialed URL errors when HTMX is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e00719bc50832fbbcc260f46b7f9ad