### PR TITLE
feat: refresh admin console theming

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -1,120 +1,237 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="space-y-8">
-  <div class="rounded-md border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-700">
-    管理后台的所有表单均直接调用 <code class="font-mono">/api/*</code> 接口，请按接口契约填写字段；
-    若提交失败将展示后端返回的原始错误信息，便于排查。
-  </div>
-  <section class="rounded-lg border border-slate-200 bg-white shadow-sm">
-    <nav class="border-b border-slate-200 px-6 pt-6" aria-label="Sections">
-      <ul class="flex flex-wrap gap-3 text-sm font-medium text-slate-500">
-        <li>
-          <a
-            href="?tab=links"
-            class="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors {% if active_tab == 'links' %}bg-sky-100 text-sky-700{% else %}hover:bg-slate-100{% endif %}"
-          >
-            <span class="h-2 w-2 rounded-full {% if active_tab == 'links' %}bg-sky-500{% else %}bg-slate-300{% endif %}"></span>
-            短链 (
-            <span
-              id="short-link-count"
-              hx-get="/admin/links/count"
-              hx-trigger="load, refresh-links from:body"
-              hx-swap="outerHTML"
-            >
-              {{ short_links|length }}
-            </span>
-            )
-          </a>
-        </li>
-        <li>
-          <a
-            href="?tab=subdomains"
-            class="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors {% if active_tab == 'subdomains' %}bg-sky-100 text-sky-700{% else %}hover:bg-slate-100{% endif %}"
-          >
-            <span class="h-2 w-2 rounded-full {% if active_tab == 'subdomains' %}bg-sky-500{% else %}bg-slate-300{% endif %}"></span>
-            子域跳转 (
-            {% with count=subdomains|length %}
-            {% include "admin/partials/subdomain_count.html" %}
-            {% endwith %}
-            )
-          </a>
-        </li>
-      </ul>
+<div class="theme-layout">
+  <section class="theme-gallery">
+    <div class="theme-gallery__header">
+      <span class="theme-eyebrow">主题预览</span>
+      <h2 class="theme-gallery__title">选择你的管理后台风格</h2>
+      <p class="theme-gallery__description">
+        登录、短链与子域管理界面提供多种视觉主题。下方卡片支持实时预览与一键切换，帮助团队匹配不同品牌调性或活动氛围。
+      </p>
+    </div>
+    <div class="theme-gallery__grid">
+      <article
+        class="theme-preview-card"
+        data-theme-option="aurora"
+        tabindex="0"
+        role="button"
+        aria-label="切换至 Aurora Glow 主题预览"
+      >
+        <div class="theme-preview-card__header">
+          <span class="theme-preview-card__title">Aurora Glow</span>
+          <span class="theme-preview-card__tag">清新渐变 · 光感玻璃</span>
+        </div>
+        <div class="theme-preview-card__canvas">
+          <div class="theme-preview-surface theme-preview-surface--login">
+            <div class="theme-preview-label theme-preview-label--wide"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-button-row">
+              <div class="theme-preview-button"></div>
+            </div>
+          </div>
+          <div class="theme-preview-surface">
+            <div class="theme-preview-label"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-label theme-preview-label--narrow"></div>
+            <div class="theme-preview-button-row">
+              <div class="theme-preview-button"></div>
+              <div class="theme-preview-button theme-preview-button--ghost"></div>
+            </div>
+          </div>
+        </div>
+        <div class="theme-preview-card__actions">
+          <button type="button" class="theme-button theme-button--solid" data-theme-apply="aurora">
+            使用 Aurora Glow
+          </button>
+          <p>渐变玻璃与柔和阴影为后台营造灵动氛围，适合品牌推广、营销活动或需要突出科技感的场景。</p>
+        </div>
+      </article>
+      <article
+        class="theme-preview-card"
+        data-theme-option="nebula"
+        tabindex="0"
+        role="button"
+        aria-label="切换至 Nebula Pulse 主题预览"
+      >
+        <div class="theme-preview-card__header">
+          <span class="theme-preview-card__title">Nebula Pulse</span>
+          <span class="theme-preview-card__tag">霓虹夜色 · 深色宇宙</span>
+        </div>
+        <div class="theme-preview-card__canvas">
+          <div class="theme-preview-surface theme-preview-surface--login">
+            <div class="theme-preview-label theme-preview-label--wide"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-button-row">
+              <div class="theme-preview-button"></div>
+            </div>
+          </div>
+          <div class="theme-preview-surface">
+            <div class="theme-preview-label"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-label theme-preview-label--narrow"></div>
+            <div class="theme-preview-button-row">
+              <div class="theme-preview-button"></div>
+              <div class="theme-preview-button theme-preview-button--ghost"></div>
+            </div>
+          </div>
+        </div>
+        <div class="theme-preview-card__actions">
+          <button type="button" class="theme-button theme-button--solid" data-theme-apply="nebula">
+            使用 Nebula Pulse
+          </button>
+          <p>深色基调搭配霓虹蓝光，适合偏开发者、夜间模式或需要沉浸式体验的 SaaS 管理后台。</p>
+        </div>
+      </article>
+      <article
+        class="theme-preview-card"
+        data-theme-option="noir"
+        tabindex="0"
+        role="button"
+        aria-label="切换至 Noir Contrast 主题预览"
+      >
+        <div class="theme-preview-card__header">
+          <span class="theme-preview-card__title">Noir Contrast</span>
+          <span class="theme-preview-card__tag">极简留白 · 强烈对比</span>
+        </div>
+        <div class="theme-preview-card__canvas">
+          <div class="theme-preview-surface theme-preview-surface--login">
+            <div class="theme-preview-label theme-preview-label--wide"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-button-row">
+              <div class="theme-preview-button"></div>
+            </div>
+          </div>
+          <div class="theme-preview-surface">
+            <div class="theme-preview-label"></div>
+            <div class="theme-preview-input"></div>
+            <div class="theme-preview-label theme-preview-label--narrow"></div>
+            <div class="theme-preview-button-row">
+              <div class="theme-preview-button"></div>
+              <div class="theme-preview-button theme-preview-button--ghost"></div>
+            </div>
+          </div>
+        </div>
+        <div class="theme-preview-card__actions">
+          <button type="button" class="theme-button theme-button--solid" data-theme-apply="noir">
+            使用 Noir Contrast
+          </button>
+          <p>经典黑白配色搭配红色点缀，兼顾商务感与冲击力，适合需要稳重又不失锋芒的企业后台。</p>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section class="theme-shell">
+    <div class="theme-shell__banner">
+      <div class="theme-tagline">
+        管理后台的所有表单均直接调用 <code>/api/*</code> 接口，请按接口契约填写字段；若提交失败会返回后端原始错误信息，便于快速排查。
+      </div>
+    </div>
+    <nav class="theme-tabs" aria-label="Sections">
+      <a
+        href="?tab=links"
+        class="theme-tab {% if active_tab == 'links' %}is-active{% endif %}"
+      >
+        <span class="theme-tab__dot"></span>
+        短链 (
+        <span
+          id="short-link-count"
+          hx-get="/admin/links/count"
+          hx-trigger="load, refresh-links from:body"
+          hx-swap="outerHTML"
+        >
+          {{ short_links|length }}
+        </span>
+        )
+      </a>
+      <a
+        href="?tab=subdomains"
+        class="theme-tab {% if active_tab == 'subdomains' %}is-active{% endif %}"
+      >
+        <span class="theme-tab__dot"></span>
+        子域跳转 (
+        {% with count=subdomains|length %}
+        {% include "admin/partials/subdomain_count.html" %}
+        {% endwith %}
+        )
+      </a>
     </nav>
-    <div class="px-6 pb-6">
+    <div class="theme-shell__body">
       {% if active_tab == 'links' %}
-      <div class="mt-6 space-y-6">
-        <section class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-          <div class="border-b border-slate-200 bg-slate-50 px-6 py-4">
-            <h2 class="text-base font-semibold text-slate-800">创建短链</h2>
-            <p class="mt-1 text-sm text-slate-500">
-              仅需填写目标地址，可选填短链编码。提交后表格会自动刷新。
+      <div class="theme-stack">
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">创建短链</h2>
+            <p class="theme-card__subtitle">
+              仅需填写目标地址，可选填短链编码。提交后表格会自动刷新，适合批量验证跳转配置。
             </p>
           </div>
-          <form
-            class="space-y-4 px-6 py-6"
-            action="/api/links"
-            method="post"
-            hx-post="/api/links"
-            hx-trigger="submit"
-            hx-target="#link-feedback"
-            hx-swap="innerHTML"
-            data-reset-on-success="true"
-            data-success-event="refresh-links"
-          >
-            <div class="grid gap-4 sm:grid-cols-2">
-              <div>
-                <label for="code" class="block text-sm font-medium text-slate-700">短链编码（可选）</label>
-                <input
-                  id="code"
-                  name="code"
-                  type="text"
-                  class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
-                  placeholder="留空则自动生成"
-                />
+          <div class="theme-card__body">
+            <form
+              class="theme-form"
+              action="/api/links"
+              method="post"
+              hx-post="/api/links"
+              hx-trigger="submit"
+              hx-target="#link-feedback"
+              hx-swap="innerHTML"
+              data-reset-on-success="true"
+              data-success-event="refresh-links"
+            >
+              <div class="theme-form__grid theme-form__grid--two">
+                <div class="theme-field">
+                  <label for="code" class="theme-label">短链编码（可选）</label>
+                  <input
+                    id="code"
+                    name="code"
+                    type="text"
+                    class="theme-input"
+                    placeholder="留空则自动生成"
+                  />
+                </div>
+                <div class="theme-field theme-form__span-full">
+                  <label for="target_url" class="theme-label">目标地址 *</label>
+                  <input
+                    id="target_url"
+                    name="target_url"
+                    type="url"
+                    required
+                    class="theme-input"
+                    placeholder="https://example.com/path"
+                  />
+                </div>
               </div>
-              <div class="sm:col-span-2">
-                <label for="target_url" class="block text-sm font-medium text-slate-700">目标地址 *</label>
-                <input
-                  id="target_url"
-                  name="target_url"
-                  type="url"
-                  required
-                  class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
-                  placeholder="https://example.com/path"
-                />
+              <div class="theme-form__footer">
+                <p class="theme-helper">
+                  表单直接调用 <code>POST /api/links</code>，遵循与外部调用一致的字段校验。
+                </p>
+                <button type="submit" class="theme-button theme-button--solid">
+                  保存短链
+                </button>
               </div>
-            </div>
-            <div class="flex items-center justify-between">
-              <p class="text-xs text-slate-500">
-                表单直接调用 <code class="font-mono">POST /api/links</code>，遵循与外部调用一致的校验。
-              </p>
-              <button
-                type="submit"
-                class="inline-flex items-center rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500"
-              >
-                保存短链
-              </button>
-            </div>
-          </form>
+            </form>
+          </div>
           <div
             id="link-feedback"
-            class="border-t border-slate-200 px-6 py-4 text-sm text-slate-500"
+            class="theme-feedback"
             role="status"
             aria-live="polite"
           ></div>
         </section>
-        <section class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-          <div class="border-b border-slate-200 bg-slate-50 px-6 py-4">
-            <h2 class="text-base font-semibold text-slate-800">短链列表</h2>
-            <p class="mt-1 text-sm text-slate-500">
-              列表展示当前短链、跳转目标与累计访问次数，可在操作列直接删除。
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">短链列表</h2>
+            <p class="theme-card__subtitle">
+              查看短链编码、跳转目标与访问次数，可直接在操作列进行编辑或删除。
             </p>
           </div>
           <div
             id="links-table"
-            class="bg-white"
+            class="theme-card__body theme-card__body--table"
             hx-get="/admin/links/table"
             hx-trigger="load, refresh-links from:body"
             hx-swap="innerHTML"
@@ -124,91 +241,90 @@
         </section>
       </div>
       {% else %}
-      <div class="mt-6 space-y-6">
-        <section class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-          <div class="border-b border-slate-200 bg-slate-50 px-6 py-4">
-            <h2 class="text-base font-semibold text-slate-800">创建子域跳转</h2>
-            <p class="mt-1 text-sm text-slate-500">
-              Host 请填写完整域名，状态码默认为 302，可选填为 301。
+      <div class="theme-stack">
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">创建子域跳转</h2>
+            <p class="theme-card__subtitle">
+              Host 请填写完整域名，状态码默认为 302，可按需切换为 301。成功后列表会自动刷新。
             </p>
           </div>
-          <form
-            class="space-y-4 px-6 py-6"
-            action="/api/subdomains"
-            method="post"
-            hx-post="/api/subdomains"
-            hx-trigger="submit"
-            hx-target="#subdomain-feedback"
-            hx-swap="innerHTML"
-            data-reset-on-success="true"
-            data-success-event="refresh-subdomains"
-          >
-            <div class="grid gap-4 sm:grid-cols-2">
-              <div>
-                <label for="host" class="block text-sm font-medium text-slate-700">Host *</label>
-                <input
-                  id="host"
-                  name="host"
-                  type="text"
-                  required
-                  class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
-                  placeholder="如 foo.yet.la"
-                />
+          <div class="theme-card__body">
+            <form
+              class="theme-form"
+              action="/api/subdomains"
+              method="post"
+              hx-post="/api/subdomains"
+              hx-trigger="submit"
+              hx-target="#subdomain-feedback"
+              hx-swap="innerHTML"
+              data-reset-on-success="true"
+              data-success-event="refresh-subdomains"
+            >
+              <div class="theme-form__grid theme-form__grid--three">
+                <div class="theme-field">
+                  <label for="host" class="theme-label">Host *</label>
+                  <input
+                    id="host"
+                    name="host"
+                    type="text"
+                    required
+                    class="theme-input"
+                    placeholder="如 foo.yet.la"
+                  />
+                </div>
+                <div class="theme-field">
+                  <label for="code" class="theme-label">状态码</label>
+                  <input
+                    id="code"
+                    name="code"
+                    type="number"
+                    value="302"
+                    min="301"
+                    max="302"
+                    step="1"
+                    class="theme-input"
+                  />
+                </div>
+                <div class="theme-field theme-form__span-full">
+                  <label for="target_url" class="theme-label">目标地址 *</label>
+                  <input
+                    id="target_url"
+                    name="target_url"
+                    type="url"
+                    required
+                    class="theme-input"
+                    placeholder="https://example.com"
+                  />
+                </div>
               </div>
-              <div>
-                <label for="code" class="block text-sm font-medium text-slate-700">状态码</label>
-                <input
-                  id="code"
-                  name="code"
-                  type="number"
-                  value="302"
-                  min="301"
-                  max="302"
-                  step="1"
-                  class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
-                />
+              <div class="theme-form__footer">
+                <p class="theme-helper">
+                  表单调用 <code>POST /api/subdomains</code>，与外部接口保持一致。
+                </p>
+                <button type="submit" class="theme-button theme-button--solid">
+                  保存子域跳转
+                </button>
               </div>
-              <div class="sm:col-span-2">
-                <label for="target_url" class="block text-sm font-medium text-slate-700">目标地址 *</label>
-                <input
-                  id="target_url"
-                  name="target_url"
-                  type="url"
-                  required
-                  class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
-                  placeholder="https://example.com"
-                />
-              </div>
-            </div>
-            <div class="flex items-center justify-between">
-              <p class="text-xs text-slate-500">
-                表单调用 <code class="font-mono">POST /api/subdomains</code>，与外部接口保持一致。
-              </p>
-              <button
-                type="submit"
-                class="inline-flex items-center rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-500"
-              >
-                保存子域跳转
-              </button>
-            </div>
-          </form>
+            </form>
+          </div>
           <div
             id="subdomain-feedback"
-            class="border-t border-slate-200 px-6 py-4 text-sm text-slate-500"
+            class="theme-feedback"
             role="status"
             aria-live="polite"
           ></div>
         </section>
-        <section class="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
-          <div class="border-b border-slate-200 bg-slate-50 px-6 py-4">
-            <h2 class="text-base font-semibold text-slate-800">子域跳转列表</h2>
-            <p class="mt-1 text-sm text-slate-500">
-              列表展示当前 Host、目标地址与状态码，支持直接删除。
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">子域跳转列表</h2>
+            <p class="theme-card__subtitle">
+              快速检索当前子域配置、跳转目标与状态码，可直接删除或进入编辑态。
             </p>
           </div>
           <div
             id="subdomains-table"
-            class="bg-white"
+            class="theme-card__body theme-card__body--table"
             hx-get="/admin/subdomains/table"
             hx-trigger="load, refresh-subdomains from:body"
             hx-swap="innerHTML"

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -1,52 +1,49 @@
-<tr id="short-link-row-{{ item.id }}" class="bg-slate-50">
-  <td colspan="5" class="px-4 py-4">
+<tr id="short-link-row-{{ item.id }}" class="theme-table__row theme-table__row--editing">
+  <td colspan="5" class="theme-table__cell">
     <form
-      class="space-y-4"
+      class="theme-form"
       hx-put="/api/links/{{ item.id }}"
       hx-target="#link-feedback"
       hx-swap="innerHTML"
       data-success-event="refresh-links"
     >
-      <div class="grid gap-4 sm:grid-cols-2">
-        <div>
-          <label for="code-{{ item.id }}" class="block text-xs font-medium text-slate-600">短链编码</label>
+      <div class="theme-form__grid theme-form__grid--two">
+        <div class="theme-field">
+          <label for="code-{{ item.id }}" class="theme-label">短链编码</label>
           <input
             id="code-{{ item.id }}"
             name="code"
             type="text"
             required
             value="{{ item.code }}"
-            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+            class="theme-input"
           />
         </div>
-        <div class="sm:col-span-2">
-          <label for="target-{{ item.id }}" class="block text-xs font-medium text-slate-600">目标地址</label>
+        <div class="theme-field theme-form__span-full">
+          <label for="target-{{ item.id }}" class="theme-label">目标地址</label>
           <input
             id="target-{{ item.id }}"
             name="target_url"
             type="url"
             required
             value="{{ item.target_url }}"
-            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+            class="theme-input"
           />
         </div>
       </div>
-      <div class="flex items-center justify-between">
-        <p class="text-xs text-slate-500">提交后会立即更新短链并刷新列表。</p>
-        <div class="flex items-center gap-2">
+      <div class="theme-form__footer">
+        <p class="theme-helper">提交后会立即更新短链并刷新列表。</p>
+        <div class="theme-form__actions">
           <button
             type="button"
-            class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+            class="theme-button theme-button--ghost theme-button--sm"
             hx-get="/admin/links/{{ item.id }}/row"
             hx-target="closest tr"
             hx-swap="outerHTML"
           >
             取消
           </button>
-          <button
-            type="submit"
-            class="inline-flex items-center rounded-md bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-sky-500"
-          >
+          <button type="submit" class="theme-button theme-button--solid theme-button--sm">
             保存
           </button>
         </div>

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -1,19 +1,19 @@
 <tr
   id="short-link-row-{{ item.id }}"
-  class="hover:bg-slate-50"
+  class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="px-4 py-3 font-mono text-slate-800">{{ item.code }}</td>
-  <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
-  <td class="px-4 py-3 text-slate-600">{{ item.hits }}</td>
-  <td class="px-4 py-3 text-slate-500">
+  <td class="theme-table__cell theme-table__cell--mono">{{ item.code }}</td>
+  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted">{{ item.target_url }}</td>
+  <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
+  <td class="theme-table__cell theme-table__cell--muted">
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
   </td>
-  <td class="px-4 py-3">
-    <div class="flex justify-end gap-2">
+  <td class="theme-table__cell theme-table__cell--right">
+    <div class="theme-table__actions">
       <button
         type="button"
-        class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+        class="theme-button theme-button--ghost theme-button--sm"
         hx-get="/admin/links/{{ item.id }}/edit"
         hx-target="closest tr"
         hx-swap="outerHTML"
@@ -22,7 +22,7 @@
       </button>
       <button
         type="button"
-        class="inline-flex items-center rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-600 shadow-sm transition hover:bg-rose-50"
+        class="theme-button theme-button--danger theme-button--sm"
         hx-delete="/api/links/{{ item.id }}"
         hx-target="#link-feedback"
         hx-swap="innerHTML"

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -1,22 +1,22 @@
 {% if short_links %}
-<table class="min-w-full divide-y divide-slate-200 text-left text-sm">
-  <thead class="bg-slate-50 text-slate-600">
+<table class="theme-table">
+  <thead>
     <tr>
-      <th scope="col" class="px-4 py-3 font-medium">短链编码</th>
-      <th scope="col" class="px-4 py-3 font-medium">目标地址</th>
-      <th scope="col" class="px-4 py-3 font-medium">访问次数</th>
-      <th scope="col" class="px-4 py-3 font-medium">创建时间</th>
-      <th scope="col" class="px-4 py-3 font-medium text-right">操作</th>
+      <th scope="col">短链编码</th>
+      <th scope="col">目标地址</th>
+      <th scope="col">访问次数</th>
+      <th scope="col">创建时间</th>
+      <th scope="col" class="theme-table__cell--right">操作</th>
     </tr>
   </thead>
-  <tbody class="divide-y divide-slate-100">
+  <tbody>
     {% for item in short_links %}
     {% include "admin/partials/link_row.html" %}
     {% endfor %}
   </tbody>
 </table>
 {% else %}
-<div class="px-6 py-10 text-center text-sm text-slate-500">
-  暂无短链记录，可通过上方表单或 <code class="font-mono">/api/links</code> 接口创建。
+<div class="theme-table__empty">
+  暂无短链记录，可通过上方表单或 <code>/api/links</code> 接口创建。
 </div>
 {% endif %}

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -1,26 +1,26 @@
-<tr id="subdomain-row-{{ item.id }}" class="bg-slate-50">
-  <td colspan="6" class="px-4 py-4">
+<tr id="subdomain-row-{{ item.id }}" class="theme-table__row theme-table__row--editing">
+  <td colspan="6" class="theme-table__cell">
     <form
-      class="space-y-4"
+      class="theme-form"
       hx-put="/api/subdomains/{{ item.id }}"
       hx-target="#subdomain-feedback"
       hx-swap="innerHTML"
       data-success-event="refresh-subdomains"
     >
-      <div class="grid gap-4 sm:grid-cols-3">
-        <div class="sm:col-span-1">
-          <label for="host-{{ item.id }}" class="block text-xs font-medium text-slate-600">Host</label>
+      <div class="theme-form__grid theme-form__grid--three">
+        <div class="theme-field">
+          <label for="host-{{ item.id }}" class="theme-label">Host</label>
           <input
             id="host-{{ item.id }}"
             name="host"
             type="text"
             required
             value="{{ item.host }}"
-            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+            class="theme-input"
           />
         </div>
-        <div>
-          <label for="code-{{ item.id }}" class="block text-xs font-medium text-slate-600">状态码</label>
+        <div class="theme-field">
+          <label for="code-{{ item.id }}" class="theme-label">状态码</label>
           <input
             id="code-{{ item.id }}"
             name="code"
@@ -30,37 +30,34 @@
             step="1"
             required
             value="{{ item.code }}"
-            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+            class="theme-input"
           />
         </div>
-        <div class="sm:col-span-3">
-          <label for="target-{{ item.id }}" class="block text-xs font-medium text-slate-600">目标地址</label>
+        <div class="theme-field theme-form__span-full">
+          <label for="target-{{ item.id }}" class="theme-label">目标地址</label>
           <input
             id="target-{{ item.id }}"
             name="target_url"
             type="url"
             required
             value="{{ item.target_url }}"
-            class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500"
+            class="theme-input"
           />
         </div>
       </div>
-      <div class="flex items-center justify-between">
-        <p class="text-xs text-slate-500">更新后会覆盖现有跳转配置并刷新列表。</p>
-        <div class="flex items-center gap-2">
+      <div class="theme-form__footer">
+        <p class="theme-helper">更新后会覆盖现有跳转配置并刷新列表。</p>
+        <div class="theme-form__actions">
           <button
             type="button"
-            class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+            class="theme-button theme-button--ghost theme-button--sm"
             hx-get="/admin/subdomains/{{ item.id }}/row"
             hx-target="closest tr"
             hx-swap="outerHTML"
           >
             取消
           </button>
-          <button
-            type="submit"
-            class="inline-flex items-center rounded-md bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-sky-500"
-          >
+          <button type="submit" class="theme-button theme-button--solid theme-button--sm">
             保存
           </button>
         </div>

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -1,20 +1,20 @@
 <tr
   id="subdomain-row-{{ item.id }}"
-  class="hover:bg-slate-50"
+  class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="px-4 py-3 font-mono text-slate-800">{{ item.host }}</td>
-  <td class="px-4 py-3 text-slate-600 break-words">{{ item.target_url }}</td>
-  <td class="px-4 py-3 text-slate-600">{{ item.code }}</td>
-  <td class="px-4 py-3 text-slate-600">{{ item.hits }}</td>
-  <td class="px-4 py-3 text-slate-500">
+  <td class="theme-table__cell theme-table__cell--mono">{{ item.host }}</td>
+  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted">{{ item.target_url }}</td>
+  <td class="theme-table__cell theme-table__cell--muted">{{ item.code }}</td>
+  <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
+  <td class="theme-table__cell theme-table__cell--muted">
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
   </td>
-  <td class="px-4 py-3">
-    <div class="flex justify-end gap-2">
+  <td class="theme-table__cell theme-table__cell--right">
+    <div class="theme-table__actions">
       <button
         type="button"
-        class="inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-slate-100"
+        class="theme-button theme-button--ghost theme-button--sm"
         hx-get="/admin/subdomains/{{ item.id }}/edit"
         hx-target="closest tr"
         hx-swap="outerHTML"
@@ -23,7 +23,7 @@
       </button>
       <button
         type="button"
-        class="inline-flex items-center rounded-md border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-600 shadow-sm transition hover:bg-rose-50"
+        class="theme-button theme-button--danger theme-button--sm"
         hx-delete="/api/subdomains/{{ item.id }}"
         hx-target="#subdomain-feedback"
         hx-swap="innerHTML"

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -1,23 +1,23 @@
 {% if subdomains %}
-<table class="min-w-full divide-y divide-slate-200 text-left text-sm">
-  <thead class="bg-slate-50 text-slate-600">
+<table class="theme-table">
+  <thead>
     <tr>
-      <th scope="col" class="px-4 py-3 font-medium">Host</th>
-      <th scope="col" class="px-4 py-3 font-medium">目标地址</th>
-      <th scope="col" class="px-4 py-3 font-medium">状态码</th>
-      <th scope="col" class="px-4 py-3 font-medium">访问次数</th>
-      <th scope="col" class="px-4 py-3 font-medium">创建时间</th>
-      <th scope="col" class="px-4 py-3 font-medium text-right">操作</th>
+      <th scope="col">Host</th>
+      <th scope="col">目标地址</th>
+      <th scope="col">状态码</th>
+      <th scope="col">访问次数</th>
+      <th scope="col">创建时间</th>
+      <th scope="col" class="theme-table__cell--right">操作</th>
     </tr>
   </thead>
-  <tbody class="divide-y divide-slate-100">
+  <tbody>
     {% for item in subdomains %}
     {% include "admin/partials/subdomain_row.html" %}
     {% endfor %}
   </tbody>
 </table>
 {% else %}
-<div class="px-6 py-10 text-center text-sm text-slate-500">
-  暂无子域跳转规则，可通过上方表单或 <code class="font-mono">/api/subdomains</code> 接口创建。
+<div class="theme-table__empty">
+  暂无子域跳转规则，可通过上方表单或 <code>/api/subdomains</code> 接口创建。
 </div>
 {% endif %}

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -4,12 +4,898 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}Yet.la 管理后台{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.3/dist/tailwind.min.css"
       integrity="sha384-4r7vpQCeYrOJvmSesi2atCkQ3pWhhi9z3pMsm9YaOGCE1zmdv8cE9VrjC2bX9msd"
       crossorigin="anonymous"
     />
+    <script>
+      (function () {
+        var fallback = "aurora";
+        try {
+          if (typeof window !== "undefined" && window.localStorage) {
+            var stored = window.localStorage.getItem("yetla-admin-theme");
+            if (stored) {
+              fallback = stored;
+            }
+          }
+        } catch (error) {
+          /* ignore storage errors */
+        }
+
+        try {
+          document.documentElement.setAttribute("data-theme", fallback);
+        } catch (error) {
+          /* ignore */
+        }
+      })();
+    </script>
+    <style>
+      :root {
+        color-scheme: light;
+        --font-body: "Inter", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", "Source Han Sans SC", sans-serif;
+        --font-display: "Space Grotesk", "Inter", "Noto Sans SC", sans-serif;
+        --font-mono: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Consolas, monospace;
+        --radius-lg: 24px;
+        --radius-md: 18px;
+        --radius-sm: 12px;
+        --shadow-soft: 0 24px 45px rgba(15, 23, 42, 0.1);
+        --shadow-glow: 0 20px 45px rgba(56, 189, 248, 0.18);
+        --theme-page: radial-gradient(circle at 0% -10%, #ecf1ff 0%, #f9fcff 40%, #f2f4ff 100%);
+        --theme-page-overlay: radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.12), transparent 60%);
+        --theme-text-primary: #111827;
+        --theme-text-secondary: #4b5563;
+        --theme-muted: #6b7280;
+        --theme-primary: #6366f1;
+        --theme-primary-strong: #4f46e5;
+        --theme-on-primary: #ffffff;
+        --theme-hero-bg: linear-gradient(135deg, rgba(99, 102, 241, 0.92), rgba(56, 189, 248, 0.9));
+        --theme-hero-border: rgba(255, 255, 255, 0.28);
+        --theme-hero-text: #f8fafc;
+        --theme-surface: rgba(255, 255, 255, 0.82);
+        --theme-surface-strong: rgba(255, 255, 255, 0.94);
+        --theme-surface-border: rgba(148, 163, 184, 0.35);
+        --theme-card-header-bg: rgba(255, 255, 255, 0.58);
+        --theme-input-bg: rgba(255, 255, 255, 0.92);
+        --theme-input-border: rgba(148, 163, 184, 0.45);
+        --theme-input-focus-border: rgba(99, 102, 241, 0.7);
+        --theme-input-focus-shadow: 0 0 0 4px rgba(99, 102, 241, 0.14);
+        --theme-button-solid-bg: var(--theme-primary);
+        --theme-button-solid-hover: var(--theme-primary-strong);
+        --theme-button-border: rgba(99, 102, 241, 0.28);
+        --theme-button-ghost-bg: rgba(99, 102, 241, 0.12);
+        --theme-button-ghost-hover-bg: rgba(99, 102, 241, 0.18);
+        --theme-danger-bg: rgba(244, 63, 94, 0.12);
+        --theme-danger-border: rgba(244, 63, 94, 0.32);
+        --theme-danger-text: #be123c;
+        --theme-table-head-bg: rgba(236, 242, 255, 0.9);
+        --theme-table-row-hover: rgba(99, 102, 241, 0.08);
+        --theme-pill-bg: rgba(99, 102, 241, 0.18);
+        --theme-pill-text: var(--theme-primary-strong);
+        --theme-tab-bg: rgba(255, 255, 255, 0.6);
+        --theme-tab-border: rgba(148, 163, 184, 0.35);
+        --theme-tab-hover-bg: rgba(99, 102, 241, 0.12);
+        --theme-tab-active-bg: rgba(99, 102, 241, 0.18);
+        --theme-tab-active-text: var(--theme-primary-strong);
+        --theme-scrollbar: rgba(79, 70, 229, 0.35);
+        --theme-preview-aurora: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(56, 189, 248, 0.35));
+        --theme-preview-nebula: linear-gradient(135deg, rgba(14, 165, 233, 0.3), rgba(99, 102, 241, 0.34));
+        --theme-preview-noir: linear-gradient(135deg, rgba(15, 23, 42, 0.35), rgba(239, 68, 68, 0.28));
+      }
+
+      :root[data-theme="nebula"] {
+        color-scheme: dark;
+        --theme-page: radial-gradient(circle at 20% 20%, #0f172a 0%, #020617 55%, #000212 100%);
+        --theme-page-overlay: radial-gradient(circle at 80% 10%, rgba(14, 165, 233, 0.24), transparent 55%);
+        --theme-text-primary: #e2e8f0;
+        --theme-text-secondary: #cbd5f5;
+        --theme-muted: #94a3b8;
+        --theme-primary: #38bdf8;
+        --theme-primary-strong: #0ea5e9;
+        --theme-on-primary: #05152b;
+        --theme-hero-bg: linear-gradient(135deg, rgba(56, 189, 248, 0.35), rgba(129, 140, 248, 0.28));
+        --theme-hero-border: rgba(148, 163, 184, 0.28);
+        --theme-hero-text: #f8fafc;
+        --theme-surface: rgba(15, 23, 42, 0.78);
+        --theme-surface-strong: rgba(15, 23, 42, 0.92);
+        --theme-surface-border: rgba(94, 234, 212, 0.18);
+        --theme-card-header-bg: rgba(30, 41, 59, 0.72);
+        --theme-input-bg: rgba(15, 23, 42, 0.9);
+        --theme-input-border: rgba(148, 163, 184, 0.28);
+        --theme-input-focus-border: rgba(59, 130, 246, 0.8);
+        --theme-input-focus-shadow: 0 0 0 4px rgba(56, 189, 248, 0.2);
+        --theme-button-border: rgba(56, 189, 248, 0.35);
+        --theme-button-ghost-bg: rgba(56, 189, 248, 0.12);
+        --theme-button-ghost-hover-bg: rgba(59, 130, 246, 0.18);
+        --theme-danger-bg: rgba(248, 113, 113, 0.16);
+        --theme-danger-border: rgba(248, 113, 113, 0.32);
+        --theme-danger-text: #fca5a5;
+        --theme-table-head-bg: rgba(15, 23, 42, 0.72);
+        --theme-table-row-hover: rgba(59, 130, 246, 0.16);
+        --theme-pill-bg: rgba(56, 189, 248, 0.18);
+        --theme-pill-text: #bae6fd;
+        --theme-tab-bg: rgba(15, 23, 42, 0.72);
+        --theme-tab-border: rgba(56, 189, 248, 0.2);
+        --theme-tab-hover-bg: rgba(56, 189, 248, 0.16);
+        --theme-tab-active-bg: rgba(129, 140, 248, 0.28);
+        --theme-tab-active-text: #e0e7ff;
+        --theme-scrollbar: rgba(125, 211, 252, 0.45);
+      }
+
+      :root[data-theme="noir"] {
+        color-scheme: light;
+        --theme-page: linear-gradient(160deg, #0f172a 0%, #f8fafc 52%, #f1f5f9 100%);
+        --theme-page-overlay: radial-gradient(circle at 10% 15%, rgba(239, 68, 68, 0.15), transparent 55%);
+        --theme-text-primary: #111827;
+        --theme-text-secondary: #374151;
+        --theme-muted: #475569;
+        --theme-primary: #ef4444;
+        --theme-primary-strong: #dc2626;
+        --theme-on-primary: #fff5f5;
+        --theme-hero-bg: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(239, 68, 68, 0.72));
+        --theme-hero-border: rgba(255, 255, 255, 0.22);
+        --theme-hero-text: #f8fafc;
+        --theme-surface: rgba(255, 255, 255, 0.84);
+        --theme-surface-strong: rgba(255, 255, 255, 0.94);
+        --theme-surface-border: rgba(15, 23, 42, 0.12);
+        --theme-card-header-bg: rgba(248, 250, 252, 0.72);
+        --theme-input-bg: rgba(255, 255, 255, 0.92);
+        --theme-input-border: rgba(148, 163, 184, 0.35);
+        --theme-input-focus-border: rgba(239, 68, 68, 0.7);
+        --theme-input-focus-shadow: 0 0 0 4px rgba(239, 68, 68, 0.14);
+        --theme-button-border: rgba(17, 24, 39, 0.16);
+        --theme-button-ghost-bg: rgba(17, 24, 39, 0.08);
+        --theme-button-ghost-hover-bg: rgba(17, 24, 39, 0.12);
+        --theme-table-head-bg: rgba(248, 250, 252, 0.88);
+        --theme-table-row-hover: rgba(15, 23, 42, 0.06);
+        --theme-pill-bg: rgba(17, 24, 39, 0.12);
+        --theme-pill-text: #111827;
+        --theme-tab-bg: rgba(255, 255, 255, 0.72);
+        --theme-tab-border: rgba(17, 24, 39, 0.12);
+        --theme-tab-hover-bg: rgba(17, 24, 39, 0.12);
+        --theme-tab-active-bg: rgba(239, 68, 68, 0.16);
+        --theme-tab-active-text: #b91c1c;
+        --theme-scrollbar: rgba(239, 68, 68, 0.35);
+      }
+
+      body.theme-body {
+        min-height: 100vh;
+        font-family: var(--font-body);
+        background: var(--theme-page);
+        background-attachment: fixed;
+        color: var(--theme-text-primary);
+        transition: background 0.6s ease, color 0.3s ease;
+      }
+
+      body.theme-body::before {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background-image: var(--theme-page-overlay);
+        pointer-events: none;
+        z-index: 0;
+        opacity: 1;
+        transition: opacity 0.4s ease;
+      }
+
+      main.theme-main,
+      header.theme-hero {
+        position: relative;
+        z-index: 1;
+      }
+
+      header.theme-hero {
+        padding: 3.5rem 1.5rem 2.5rem;
+      }
+
+      .theme-hero__inner {
+        position: relative;
+        margin: 0 auto;
+        max-width: 1120px;
+        padding: 2.75rem 3rem;
+        border-radius: var(--radius-lg);
+        background: var(--theme-hero-bg);
+        overflow: hidden;
+        box-shadow: var(--shadow-soft);
+        border: 1px solid var(--theme-hero-border);
+        color: var(--theme-hero-text);
+      }
+
+      .theme-hero__inner::after {
+        content: "";
+        position: absolute;
+        inset: 15% -30% auto auto;
+        width: 320px;
+        height: 320px;
+        background: radial-gradient(circle at center, rgba(255, 255, 255, 0.28), transparent 70%);
+        filter: blur(0px);
+        opacity: 0.65;
+        pointer-events: none;
+      }
+
+      .theme-hero__meta {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.18);
+        backdrop-filter: blur(12px);
+        font-size: 0.85rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin-bottom: 1.5rem;
+      }
+
+      .theme-hero__title {
+        font-family: var(--font-display);
+        font-size: clamp(2.25rem, 3vw + 1rem, 3.25rem);
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        margin: 0;
+      }
+
+      .theme-hero__subtitle {
+        margin-top: 1rem;
+        max-width: 620px;
+        font-size: 1rem;
+        line-height: 1.75;
+        color: rgba(248, 250, 252, 0.85);
+      }
+
+      .theme-main {
+        padding: 0 1.5rem 4rem;
+      }
+
+      .theme-layout {
+        max-width: 1120px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 3rem;
+      }
+
+      .theme-gallery {
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+        padding: 0 0.5rem;
+      }
+
+      .theme-gallery__header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        max-width: 720px;
+      }
+
+      .theme-eyebrow {
+        font-size: 0.85rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--theme-muted);
+        font-weight: 600;
+      }
+
+      .theme-gallery__title {
+        font-family: var(--font-display);
+        font-size: clamp(1.65rem, 2vw + 0.5rem, 2.2rem);
+        color: var(--theme-text-primary);
+        margin: 0;
+      }
+
+      .theme-gallery__description {
+        color: var(--theme-text-secondary);
+        font-size: 1rem;
+        line-height: 1.8;
+      }
+
+      .theme-gallery__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.5rem;
+      }
+
+      .theme-preview-card {
+        position: relative;
+        padding: 1.75rem;
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--theme-surface-border);
+        background: var(--theme-surface);
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+        display: flex;
+        flex-direction: column;
+        gap: 1.35rem;
+        transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+        cursor: pointer;
+      }
+
+      .theme-preview-card::before {
+        content: "";
+        position: absolute;
+        inset: 8px 12px;
+        border-radius: calc(var(--radius-lg) - 12px);
+        background: var(--theme-preview-aurora);
+        opacity: 0;
+        transition: opacity 0.3s ease;
+        z-index: 0;
+      }
+
+      .theme-preview-card[data-theme-option="nebula"]::before {
+        background: var(--theme-preview-nebula);
+      }
+
+      .theme-preview-card[data-theme-option="noir"]::before {
+        background: var(--theme-preview-noir);
+      }
+
+      .theme-preview-card:hover,
+      .theme-preview-card:focus-within {
+        transform: translateY(-6px);
+        box-shadow: 0 24px 55px rgba(15, 23, 42, 0.12);
+      }
+
+      .theme-preview-card:hover::before,
+      .theme-preview-card.is-preview::before,
+      .theme-preview-card.is-active::before {
+        opacity: 1;
+      }
+
+      .theme-preview-card.is-active {
+        border-color: transparent;
+        box-shadow: var(--shadow-glow);
+      }
+
+      .theme-preview-card__header {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+      }
+
+      .theme-preview-card__title {
+        font-family: var(--font-display);
+        font-size: 1.15rem;
+        font-weight: 600;
+        color: var(--theme-text-primary);
+      }
+
+      .theme-preview-card__tag {
+        font-size: 0.85rem;
+        color: var(--theme-muted);
+      }
+
+      .theme-preview-card__canvas {
+        position: relative;
+        z-index: 1;
+        display: grid;
+        gap: 1.1rem;
+      }
+
+      .theme-preview-surface {
+        background: var(--theme-surface-strong);
+        border-radius: var(--radius-md);
+        border: 1px solid var(--theme-surface-border);
+        padding: 1rem 1.2rem;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+
+      .theme-preview-surface--login {
+        gap: 0.75rem;
+      }
+
+      .theme-preview-label {
+        width: 50%;
+        height: 0.55rem;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.35);
+      }
+
+      .theme-preview-label--wide {
+        width: 70%;
+      }
+
+      .theme-preview-label--narrow {
+        width: 35%;
+      }
+
+      .theme-preview-input {
+        height: 0.85rem;
+        border-radius: 999px;
+        background: rgba(148, 163, 184, 0.55);
+      }
+
+      .theme-preview-button-row {
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .theme-preview-button {
+        flex: 1;
+        height: 32px;
+        border-radius: 999px;
+        background: rgba(99, 102, 241, 0.18);
+      }
+
+      .theme-preview-button--ghost {
+        background: rgba(148, 163, 184, 0.3);
+      }
+
+      .theme-preview-card[data-theme-option="nebula"] .theme-preview-input {
+        background: rgba(148, 163, 184, 0.4);
+      }
+
+      .theme-preview-card[data-theme-option="nebula"] .theme-preview-button {
+        background: rgba(56, 189, 248, 0.28);
+      }
+
+      .theme-preview-card[data-theme-option="nebula"] .theme-preview-button--ghost {
+        background: rgba(129, 140, 248, 0.28);
+      }
+
+      .theme-preview-card[data-theme-option="noir"] .theme-preview-button {
+        background: rgba(239, 68, 68, 0.24);
+      }
+
+      .theme-preview-card[data-theme-option="noir"] .theme-preview-button--ghost {
+        background: rgba(15, 23, 42, 0.2);
+      }
+
+      .theme-preview-card__actions {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .theme-preview-card__actions p {
+        font-size: 0.9rem;
+        color: var(--theme-text-secondary);
+        line-height: 1.6;
+      }
+
+      .theme-shell {
+        background: var(--theme-surface);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--theme-surface-border);
+        box-shadow: var(--shadow-soft);
+        backdrop-filter: blur(16px);
+        overflow: hidden;
+      }
+
+      .theme-shell__banner {
+        padding: 2.25rem 2.5rem 0;
+      }
+
+      .theme-shell__banner .theme-tagline {
+        margin: 0 0 1.75rem;
+      }
+
+      .theme-tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        padding: 2.5rem 2.5rem 0;
+      }
+
+      .theme-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        border-radius: 999px;
+        padding: 0.6rem 1.4rem;
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: var(--theme-text-secondary);
+        background: var(--theme-tab-bg);
+        border: 1px solid var(--theme-tab-border);
+        transition: background 0.25s ease, color 0.25s ease, box-shadow 0.25s ease, border 0.25s ease;
+      }
+
+      .theme-tab__dot {
+        display: inline-flex;
+        width: 0.45rem;
+        height: 0.45rem;
+        border-radius: 50%;
+        background: rgba(148, 163, 184, 0.6);
+        transition: transform 0.25s ease, background 0.25s ease;
+      }
+
+      .theme-tab:hover,
+      .theme-tab:focus-visible {
+        background: var(--theme-tab-hover-bg);
+        border-color: transparent;
+      }
+
+      .theme-tab.is-active {
+        background: var(--theme-tab-active-bg);
+        color: var(--theme-tab-active-text);
+        box-shadow: var(--shadow-glow);
+        border-color: transparent;
+      }
+
+      .theme-tab.is-active .theme-tab__dot {
+        background: var(--theme-primary-strong);
+        transform: scale(1.2);
+      }
+
+      .theme-shell__body {
+        padding: 2.5rem;
+      }
+
+      .theme-stack {
+        display: flex;
+        flex-direction: column;
+        gap: 2.25rem;
+      }
+
+      .theme-card {
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--theme-surface-border);
+        background: var(--theme-surface-strong);
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+        overflow: hidden;
+      }
+
+      .theme-card__header {
+        padding: 1.8rem 2.25rem 1.4rem;
+        border-bottom: 1px solid var(--theme-surface-border);
+        background: var(--theme-card-header-bg);
+        backdrop-filter: blur(12px);
+      }
+
+      .theme-card__title {
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: var(--theme-text-primary);
+        margin: 0;
+      }
+
+      .theme-card__subtitle {
+        margin-top: 0.75rem;
+        color: var(--theme-text-secondary);
+        line-height: 1.6;
+        font-size: 0.95rem;
+      }
+
+      .theme-card__body {
+        padding: 2.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+      }
+
+      .theme-card__body--table {
+        padding: 0;
+        display: block;
+        overflow-x: auto;
+      }
+
+      .theme-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+      }
+
+      .theme-form__grid {
+        display: grid;
+        gap: 1.35rem;
+      }
+
+      .theme-form__grid--two {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      }
+
+      .theme-form__grid--three {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+
+      .theme-form__span-full {
+        grid-column: 1 / -1;
+      }
+
+      .theme-field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .theme-label {
+        font-size: 0.9rem;
+        font-weight: 600;
+        color: var(--theme-text-secondary);
+      }
+
+      .theme-input,
+      .theme-select {
+        width: 100%;
+        padding: 0.85rem 1rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--theme-input-border);
+        background: var(--theme-input-bg);
+        color: var(--theme-text-primary);
+        font-size: 0.95rem;
+        transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+      }
+
+      .theme-input:focus,
+      .theme-input:focus-visible,
+      .theme-select:focus,
+      .theme-select:focus-visible {
+        outline: none;
+        border-color: var(--theme-input-focus-border);
+        box-shadow: var(--theme-input-focus-shadow);
+      }
+
+      .theme-helper {
+        font-size: 0.85rem;
+        color: var(--theme-muted);
+        line-height: 1.5;
+      }
+
+      .theme-form__footer {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .theme-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        border-radius: 999px;
+        padding: 0.7rem 1.5rem;
+        font-weight: 600;
+        font-size: 0.95rem;
+        border: 1px solid transparent;
+        background: transparent;
+        color: var(--theme-text-primary);
+        transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+      }
+
+      .theme-button:hover,
+      .theme-button:focus-visible {
+        transform: translateY(-1px);
+      }
+
+      .theme-button--solid {
+        background: var(--theme-button-solid-bg);
+        color: var(--theme-on-primary);
+        box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+      }
+
+      .theme-button--solid:hover,
+      .theme-button--solid:focus-visible {
+        background: var(--theme-button-solid-hover);
+      }
+
+      .theme-button--ghost {
+        background: var(--theme-button-ghost-bg);
+        color: var(--theme-tab-active-text, var(--theme-primary));
+        border-color: var(--theme-button-border);
+      }
+
+      .theme-button--ghost:hover,
+      .theme-button--ghost:focus-visible {
+        background: var(--theme-button-ghost-hover-bg);
+        border-color: transparent;
+      }
+
+      .theme-button--danger {
+        background: var(--theme-danger-bg);
+        color: var(--theme-danger-text);
+        border-color: var(--theme-danger-border);
+      }
+
+      .theme-button--sm {
+        padding: 0.45rem 1rem;
+        font-size: 0.82rem;
+      }
+
+      .theme-feedback {
+        border-top: 1px solid var(--theme-surface-border);
+        padding: 1.35rem 2.25rem;
+        font-size: 0.9rem;
+        color: var(--theme-text-secondary);
+        background: rgba(255, 255, 255, 0.35);
+      }
+
+      .theme-table {
+        width: 100%;
+        border-collapse: separate;
+        border-spacing: 0;
+        font-size: 0.92rem;
+      }
+
+      .theme-table thead th {
+        text-align: left;
+        padding: 0.95rem 1.5rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        font-size: 0.78rem;
+        color: var(--theme-muted);
+        background: var(--theme-table-head-bg);
+      }
+
+      .theme-table tbody tr {
+        transition: background 0.25s ease;
+      }
+
+      .theme-table tbody tr:hover {
+        background: var(--theme-table-row-hover);
+      }
+
+      .theme-table__row--editing {
+        background: rgba(99, 102, 241, 0.06);
+      }
+
+      .theme-table__row--editing > .theme-table__cell {
+        border-top: none;
+        padding: 1.75rem 1.75rem;
+        background: transparent;
+      }
+
+      .theme-table tbody td {
+        padding: 1rem 1.5rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.15);
+        color: var(--theme-text-primary);
+        vertical-align: middle;
+      }
+
+      .theme-table__cell--mono {
+        font-family: var(--font-mono);
+        font-size: 0.88rem;
+      }
+
+      .theme-table__cell--muted {
+        color: var(--theme-muted);
+      }
+
+      .theme-table__cell--wrap {
+        word-break: break-all;
+      }
+
+      .theme-table__cell--right {
+        text-align: right;
+      }
+
+      .theme-table__actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+      }
+
+      .theme-table__empty {
+        padding: 2.5rem;
+        text-align: center;
+        color: var(--theme-text-secondary);
+        font-size: 0.95rem;
+      }
+
+      code {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.4rem;
+        background: rgba(15, 23, 42, 0.08);
+      }
+
+      :root[data-theme="nebula"] code {
+        background: rgba(15, 23, 42, 0.55);
+        color: #e0f2fe;
+      }
+
+      .theme-tagline {
+        padding: 1rem 1.25rem;
+        border-radius: var(--radius-md);
+        background: rgba(56, 189, 248, 0.12);
+        color: var(--theme-primary-strong);
+        border: 1px solid rgba(56, 189, 248, 0.2);
+        font-size: 0.9rem;
+        line-height: 1.6;
+      }
+
+      :root[data-theme="noir"] .theme-tagline {
+        background: rgba(17, 24, 39, 0.08);
+        color: #111827;
+        border-color: rgba(17, 24, 39, 0.12);
+      }
+
+      :root[data-theme="nebula"] .theme-tagline {
+        background: rgba(56, 189, 248, 0.16);
+        border-color: rgba(59, 130, 246, 0.28);
+        color: #e0f2fe;
+      }
+
+      .theme-table__row--editing form {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .theme-form__actions {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .theme-preview-card button.theme-button {
+        width: 100%;
+      }
+
+      @media (max-width: 768px) {
+        header.theme-hero {
+          padding: 2.5rem 1.25rem 2rem;
+        }
+
+        .theme-hero__inner {
+          padding: 2.25rem 1.75rem;
+        }
+
+        .theme-shell__body {
+          padding: 1.85rem;
+        }
+
+        .theme-card__header {
+          padding: 1.5rem 1.75rem 1.2rem;
+        }
+
+        .theme-card__body {
+          padding: 1.75rem;
+        }
+
+        .theme-tabs {
+          padding: 1.85rem 1.85rem 0;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .theme-form__footer {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .theme-form__actions {
+          width: 100%;
+          justify-content: space-between;
+        }
+
+        .theme-button {
+          width: 100%;
+        }
+      }
+
+      ::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+      }
+
+      ::-webkit-scrollbar-thumb {
+        background: var(--theme-scrollbar);
+        border-radius: 999px;
+      }
+
+      ::-webkit-scrollbar-track {
+        background: rgba(148, 163, 184, 0.15);
+      }
+    </style>
     <script
       src="https://unpkg.com/htmx.org@1.9.10"
       integrity="sha384-tPY/1+qsSVqSdz+CA0nVddOZXS6jttuPAHyBs+K6TfGsDz3jAC5vVsQt1zArhcXa"
@@ -30,19 +916,20 @@
   </head>
   {% set auth_header = request.headers.get("Authorization") if request else None %}
   <body
-    class="min-h-full text-slate-800"
+    class="theme-body"
     {% if auth_header %}hx-headers='{{ {"Authorization": auth_header}|tojson }}'{% endif %}
     {% if auth_header %}data-auth-header="{{ auth_header }}"{% endif %}
   >
-    <header class="bg-white shadow">
-      <div class="mx-auto max-w-5xl px-4 py-5 sm:px-6 lg:px-8">
-        <h1 class="text-2xl font-semibold text-slate-900">Yet.la 管理后台</h1>
-        <p class="mt-1 text-sm text-slate-500">
-          通过受保护的界面快速查看短链与子域跳转配置。
+    <header class="theme-hero">
+      <div class="theme-hero__inner">
+        <div class="theme-hero__meta">Yet.la Platform</div>
+        <h1 class="theme-hero__title">Yet.la 管理后台</h1>
+        <p class="theme-hero__subtitle">
+          通过多套主题风格快速预览、创建和管理短链与子域跳转配置，保持团队品牌体验的统一与时尚。
         </p>
       </div>
     </header>
-    <main class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+    <main class="theme-main">
       {% block content %}{% endblock %}
     </main>
   </body>


### PR DESCRIPTION
## Summary
- refresh the base admin template with new fonts, gradients, and reusable theme-driven utility classes
- add a multi-theme preview gallery and restyle the short link/subdomain forms and tables to use the new components
- enhance the admin dashboard script to support theme previews, persistence, and keyboard interactions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e067e24450832f9d1ec5943f37aa4e