### PR TITLE
Revamp admin dashboard themes and subdomain UX

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -1,5 +1,9 @@
 (function () {
   const THEME_STORAGE_KEY = "yetla-admin-theme";
+  const AVAILABLE_THEMES = ["aurora", "nebula"];
+  const DEFAULT_THEME = "aurora";
+  const RANDOM_CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const COPY_FEEDBACK_TIMEOUT = 2000;
   let storedThemeValue = null;
 
   function onReady(callback) {
@@ -24,19 +28,23 @@
     if (swap === "outerHTML") {
       if (html.trim() === "") {
         target.outerHTML = html;
+        enhanceDynamicUI();
         return;
       }
       const fragment = createFragment(html);
       const firstElement = fragment.firstElementChild;
       if (firstElement) {
         target.replaceWith(firstElement);
+        enhanceDynamicUI(firstElement);
       } else {
         target.outerHTML = html;
+        enhanceDynamicUI();
       }
       return;
     }
 
     target.innerHTML = html;
+    enhanceDynamicUI(target);
   }
 
   function resolveTarget(element, selector) {
@@ -121,6 +129,8 @@
     const swapStrategy = formLike.getAttribute("hx-swap") || "innerHTML";
     const target = resolveTarget(formLike, targetSelector);
 
+    bindDomainInputs(formLike);
+
     const formData = new FormData(formLike);
     if (
       submitter &&
@@ -183,6 +193,7 @@
       if (formLike.getAttribute("data-reset-on-success") === "true") {
         formLike.reset();
       }
+      applyPostSuccessEnhancements(formLike);
     }
     dispatchSuccessEvent(formLike);
   }
@@ -267,54 +278,70 @@
     });
   }
 
-  function setTheme(theme, { persist = false, preview = false } = {}) {
+  function sanitizeTheme(theme) {
     if (!theme) {
-      return;
+      return DEFAULT_THEME;
     }
+    return AVAILABLE_THEMES.includes(theme) ? theme : DEFAULT_THEME;
+  }
+
+  function highlightThemeToggles(activeTheme) {
+    const toggles = document.querySelectorAll("[data-theme-toggle]");
+    toggles.forEach((toggle) => {
+      const target = toggle.getAttribute("data-theme-toggle");
+      const isActive = target === activeTheme;
+      toggle.classList.toggle("is-active", Boolean(isActive));
+      toggle.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+  }
+
+  function setTheme(theme, { persist = false, preview = false } = {}) {
+    const targetTheme = sanitizeTheme(theme);
 
     const root = document.documentElement;
     const body = document.body;
 
     if (root) {
-      root.setAttribute("data-theme", theme);
+      root.setAttribute("data-theme", targetTheme);
     }
     if (body) {
-      body.setAttribute("data-theme", theme);
+      body.setAttribute("data-theme", targetTheme);
     }
 
     if (persist) {
-      storedThemeValue = theme;
+      storedThemeValue = targetTheme;
       try {
-        window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+        window.localStorage.setItem(THEME_STORAGE_KEY, targetTheme);
       } catch (error) {
         /* ignore storage failures */
       }
     }
 
-    const active = storedThemeValue || theme;
-    highlightThemeCards(active, preview ? theme : undefined);
+    const activeTheme = storedThemeValue || targetTheme;
+    highlightThemeCards(activeTheme, preview ? targetTheme : undefined);
+    highlightThemeToggles(activeTheme);
   }
 
   function getStoredTheme() {
     if (storedThemeValue) {
-      return storedThemeValue;
+      return sanitizeTheme(storedThemeValue);
     }
 
-    let saved = "aurora";
+    let saved = DEFAULT_THEME;
     try {
       const fromStorage = window.localStorage.getItem(THEME_STORAGE_KEY);
       if (fromStorage) {
-        saved = fromStorage;
+        saved = sanitizeTheme(fromStorage);
       } else {
         const attr = document.documentElement.getAttribute("data-theme");
         if (attr) {
-          saved = attr;
+          saved = sanitizeTheme(attr);
         }
       }
     } catch (error) {
       const attr = document.documentElement.getAttribute("data-theme");
       if (attr) {
-        saved = attr;
+        saved = sanitizeTheme(attr);
       }
     }
 
@@ -325,6 +352,28 @@
   function restorePersistedTheme() {
     const theme = getStoredTheme();
     setTheme(theme, { persist: false });
+  }
+
+  function bindThemeToggles() {
+    const toggles = document.querySelectorAll("[data-theme-toggle]");
+
+    if (!toggles.length) {
+      return;
+    }
+
+    toggles.forEach((toggle) => {
+      if (toggle.dataset.themeToggleBound === "true") {
+        return;
+      }
+      toggle.dataset.themeToggleBound = "true";
+      toggle.addEventListener("click", (event) => {
+        event.preventDefault();
+        const targetTheme = sanitizeTheme(toggle.getAttribute("data-theme-toggle"));
+        setTheme(targetTheme, { persist: true });
+      });
+    });
+
+    highlightThemeToggles(getStoredTheme());
   }
 
   function bindThemeGallery() {
@@ -400,14 +449,203 @@
     highlightThemeCards(saved);
   }
 
+  function bindDomainInputs(root = document) {
+    const scope = root instanceof Element ? root : document;
+    const groups = scope.querySelectorAll("[data-domain-input]");
+
+    groups.forEach((group) => {
+      if (!(group instanceof HTMLElement)) {
+        return;
+      }
+
+      if (group.dataset.domainEnhanced === "true") {
+        if (typeof group.__updateDomainValue === "function") {
+          group.__updateDomainValue();
+        }
+        return;
+      }
+
+      const input = group.querySelector("[data-domain-input-field]");
+      const hidden = group.querySelector("[data-domain-input-hidden]");
+      const rawSuffix = group.getAttribute("data-domain-suffix") || "";
+      const suffix = rawSuffix.trim();
+
+      const updateValue = () => {
+        if (!hidden) {
+          return;
+        }
+
+        if (!input) {
+          hidden.value = suffix;
+          return;
+        }
+
+        let prefixValue = input.value.trim();
+        if (prefixValue) {
+          const normalized = prefixValue.toLowerCase();
+          if (normalized !== prefixValue) {
+            input.value = normalized;
+          }
+          prefixValue = normalized;
+        }
+
+        let fullValue = "";
+        if (suffix) {
+          fullValue = prefixValue ? `${prefixValue}.${suffix}` : "";
+        } else {
+          fullValue = prefixValue;
+        }
+
+        hidden.value = fullValue;
+      };
+
+      if (input) {
+        input.addEventListener("input", updateValue);
+      }
+
+      const form = group.closest("form");
+      if (form) {
+        form.addEventListener("reset", () => {
+          window.setTimeout(updateValue, 0);
+        });
+      }
+
+      group.dataset.domainEnhanced = "true";
+      group.__updateDomainValue = updateValue;
+      updateValue();
+    });
+  }
+
+  function generateRandomCode(length) {
+    const parsed = Number.parseInt(length, 10);
+    const effectiveLength = Number.isFinite(parsed) && parsed > 0 ? parsed : 6;
+    let result = "";
+    for (let index = 0; index < effectiveLength; index += 1) {
+      const randomIndex = Math.floor(Math.random() * RANDOM_CODE_ALPHABET.length);
+      result += RANDOM_CODE_ALPHABET.charAt(randomIndex);
+    }
+    return result;
+  }
+
+  function bindCopyButtons(root = document) {
+    const scope = root instanceof Element ? root : document;
+    const buttons = scope.querySelectorAll("[data-copy-value]");
+
+    buttons.forEach((button) => {
+      if (!(button instanceof HTMLButtonElement)) {
+        return;
+      }
+      if (button.dataset.copyBound === "true") {
+        return;
+      }
+
+      let timeoutId;
+
+      const showFeedback = () => {
+        button.classList.add("is-copied");
+        clearTimeout(timeoutId);
+        timeoutId = window.setTimeout(() => {
+          button.classList.remove("is-copied");
+        }, COPY_FEEDBACK_TIMEOUT);
+      };
+
+      const fallbackCopy = (value) => {
+        const textarea = document.createElement("textarea");
+        textarea.value = value;
+        textarea.setAttribute("readonly", "true");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      };
+
+      button.addEventListener("click", async (event) => {
+        event.preventDefault();
+        const value = button.getAttribute("data-copy-value") || "";
+        if (!value) {
+          return;
+        }
+
+        try {
+          if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+            await navigator.clipboard.writeText(value);
+          } else {
+            fallbackCopy(value);
+          }
+          showFeedback();
+        } catch (error) {
+          try {
+            fallbackCopy(value);
+            showFeedback();
+          } catch (fallbackError) {
+            console.warn("Failed to copy value", fallbackError);
+          }
+        }
+      });
+
+      button.dataset.copyBound = "true";
+    });
+  }
+
+  function applyPostSuccessEnhancements(formLike) {
+    if (!(formLike instanceof HTMLFormElement)) {
+      return;
+    }
+
+    const domainGroups = formLike.querySelectorAll("[data-domain-input]");
+    domainGroups.forEach((group) => {
+      if (group && typeof group.__updateDomainValue === "function") {
+        group.__updateDomainValue();
+      }
+    });
+
+    const randomInputs = formLike.querySelectorAll("[data-random-code='true']");
+    randomInputs.forEach((input) => {
+      if (!(input instanceof HTMLInputElement)) {
+        return;
+      }
+      const length = input.getAttribute("data-random-code-length") || "6";
+      const nextValue = generateRandomCode(length);
+      input.value = nextValue;
+      input.defaultValue = nextValue;
+    });
+  }
+
+  function enhanceDynamicUI(root) {
+    bindDomainInputs(root);
+    bindCopyButtons(root);
+  }
+
   onReady(() => {
     const authHeader = document.body.dataset.authHeader || "";
     const useFallback = typeof window.htmx === "undefined";
 
     restorePersistedTheme();
+    bindThemeToggles();
     bindThemeGallery();
+    enhanceDynamicUI();
 
     if (!useFallback) {
+      document.body.addEventListener("htmx:afterSwap", (event) => {
+        const target = event.target;
+        if (target instanceof HTMLElement) {
+          enhanceDynamicUI(target);
+        } else {
+          enhanceDynamicUI();
+        }
+      });
+      document.body.addEventListener("htmx:configRequest", (event) => {
+        const source = event.target;
+        if (!(source instanceof HTMLElement)) {
+          return;
+        }
+        const form = source.closest("form");
+        if (form) {
+          bindDomainInputs(form);
+        }
+      });
       document.body.addEventListener("htmx:afterRequest", (event) => {
         const detail = event.detail || {};
         const { successful, xhr } = detail;

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -16,11 +16,11 @@
         data-theme-option="aurora"
         tabindex="0"
         role="button"
-        aria-label="切换至 Aurora Glow 主题预览"
+        aria-label="切换至 Aurora Glow 亮色主题预览"
       >
         <div class="theme-preview-card__header">
           <span class="theme-preview-card__title">Aurora Glow</span>
-          <span class="theme-preview-card__tag">清新渐变 · 光感玻璃</span>
+          <span class="theme-preview-card__tag">亮色 · 渐变玻璃</span>
         </div>
         <div class="theme-preview-card__canvas">
           <div class="theme-preview-surface theme-preview-surface--login">
@@ -43,9 +43,9 @@
         </div>
         <div class="theme-preview-card__actions">
           <button type="button" class="theme-button theme-button--solid" data-theme-apply="aurora">
-            使用 Aurora Glow
+            使用亮色主题
           </button>
-          <p>渐变玻璃与柔和阴影为后台营造灵动氛围，适合品牌推广、营销活动或需要突出科技感的场景。</p>
+          <p>清爽的渐变与柔和高光适合日间使用的运营后台，兼顾品牌展示与高对比度表单体验。</p>
         </div>
       </article>
       <article
@@ -53,11 +53,11 @@
         data-theme-option="nebula"
         tabindex="0"
         role="button"
-        aria-label="切换至 Nebula Pulse 主题预览"
+        aria-label="切换至 Nebula Pulse 暗色主题预览"
       >
         <div class="theme-preview-card__header">
           <span class="theme-preview-card__title">Nebula Pulse</span>
-          <span class="theme-preview-card__tag">霓虹夜色 · 深色宇宙</span>
+          <span class="theme-preview-card__tag">暗色 · 霓虹宇宙</span>
         </div>
         <div class="theme-preview-card__canvas">
           <div class="theme-preview-surface theme-preview-surface--login">
@@ -80,46 +80,9 @@
         </div>
         <div class="theme-preview-card__actions">
           <button type="button" class="theme-button theme-button--solid" data-theme-apply="nebula">
-            使用 Nebula Pulse
+            使用暗色主题
           </button>
-          <p>深色基调搭配霓虹蓝光，适合偏开发者、夜间模式或需要沉浸式体验的 SaaS 管理后台。</p>
-        </div>
-      </article>
-      <article
-        class="theme-preview-card"
-        data-theme-option="noir"
-        tabindex="0"
-        role="button"
-        aria-label="切换至 Noir Contrast 主题预览"
-      >
-        <div class="theme-preview-card__header">
-          <span class="theme-preview-card__title">Noir Contrast</span>
-          <span class="theme-preview-card__tag">极简留白 · 强烈对比</span>
-        </div>
-        <div class="theme-preview-card__canvas">
-          <div class="theme-preview-surface theme-preview-surface--login">
-            <div class="theme-preview-label theme-preview-label--wide"></div>
-            <div class="theme-preview-input"></div>
-            <div class="theme-preview-input"></div>
-            <div class="theme-preview-button-row">
-              <div class="theme-preview-button"></div>
-            </div>
-          </div>
-          <div class="theme-preview-surface">
-            <div class="theme-preview-label"></div>
-            <div class="theme-preview-input"></div>
-            <div class="theme-preview-label theme-preview-label--narrow"></div>
-            <div class="theme-preview-button-row">
-              <div class="theme-preview-button"></div>
-              <div class="theme-preview-button theme-preview-button--ghost"></div>
-            </div>
-          </div>
-        </div>
-        <div class="theme-preview-card__actions">
-          <button type="button" class="theme-button theme-button--solid" data-theme-apply="noir">
-            使用 Noir Contrast
-          </button>
-          <p>经典黑白配色搭配红色点缀，兼顾商务感与冲击力，适合需要稳重又不失锋芒的企业后台。</p>
+          <p>沉浸式暗色和霓虹脉冲降低夜间眩光，适合开发者和需要长时间专注操作的管理团队。</p>
         </div>
       </article>
     </div>
@@ -153,7 +116,7 @@
         class="theme-tab {% if active_tab == 'subdomains' %}is-active{% endif %}"
       >
         <span class="theme-tab__dot"></span>
-        子域跳转 (
+        子域 (
         {% with count=subdomains|length %}
         {% include "admin/partials/subdomain_count.html" %}
         {% endwith %}
@@ -167,7 +130,7 @@
           <div class="theme-card__header">
             <h2 class="theme-card__title">创建短链</h2>
             <p class="theme-card__subtitle">
-              仅需填写目标地址，可选填短链编码。提交后表格会自动刷新，适合批量验证跳转配置。
+              填写目标地址，可按需调整短链后缀；前缀 {{ short_link_prefix }} 已固定展示，提交后表格会自动刷新。
             </p>
           </div>
           <div class="theme-card__body">
@@ -184,14 +147,22 @@
             >
               <div class="theme-form__grid theme-form__grid--two">
                 <div class="theme-field">
-                  <label for="code" class="theme-label">短链编码（可选）</label>
-                  <input
-                    id="code"
-                    name="code"
-                    type="text"
-                    class="theme-input"
-                    placeholder="留空则自动生成"
-                  />
+                  <label for="code" class="theme-label">短链（可改）</label>
+                  <div class="theme-input-affix">
+                    <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_prefix }}</span>
+                    <input
+                      id="code"
+                      name="code"
+                      type="text"
+                      class="theme-input-affix__input"
+                      value="{{ short_code_suggestion or '' }}"
+                      data-random-code="true"
+                      data-random-code-length="{{ short_code_length }}"
+                      autocomplete="off"
+                      spellcheck="false"
+                      placeholder="自动生成，可修改"
+                    />
+                  </div>
                 </div>
                 <div class="theme-field theme-form__span-full">
                   <label for="target_url" class="theme-label">目标地址 *</label>
@@ -207,7 +178,7 @@
               </div>
               <div class="theme-form__footer">
                 <p class="theme-helper">
-                  表单直接调用 <code>POST /api/links</code>，遵循与外部调用一致的字段校验。
+                  表单直接调用 <code>POST /api/links</code>，默认提供随机短链编码，可在提交前调整。
                 </p>
                 <button type="submit" class="theme-button theme-button--solid">
                   保存短链
@@ -226,7 +197,7 @@
           <div class="theme-card__header">
             <h2 class="theme-card__title">短链列表</h2>
             <p class="theme-card__subtitle">
-              查看短链编码、跳转目标与访问次数，可直接在操作列进行编辑或删除。
+              查看短链、跳转目标与访问次数，可直接复制、编辑或删除。
             </p>
           </div>
           <div
@@ -244,9 +215,9 @@
       <div class="theme-stack">
         <section class="theme-card">
           <div class="theme-card__header">
-            <h2 class="theme-card__title">创建子域跳转</h2>
+            <h2 class="theme-card__title">创建子域</h2>
             <p class="theme-card__subtitle">
-              Host 请填写完整域名，状态码默认为 302，可按需切换为 301。成功后列表会自动刷新。
+              填写子域前缀即可，后缀 .{{ base_domain }} 将自动拼接；状态码默认为 302，支持在下拉菜单中切换。
             </p>
           </div>
           <div class="theme-card__body">
@@ -263,28 +234,33 @@
             >
               <div class="theme-form__grid theme-form__grid--three">
                 <div class="theme-field">
-                  <label for="host" class="theme-label">Host *</label>
-                  <input
-                    id="host"
-                    name="host"
-                    type="text"
-                    required
-                    class="theme-input"
-                    placeholder="如 foo.yet.la"
-                  />
+                  <label for="subdomain-prefix" class="theme-label">子域 *</label>
+                  <div
+                    class="theme-input-affix"
+                    data-domain-input
+                    data-domain-suffix="{{ base_domain }}"
+                  >
+                    <input
+                      id="subdomain-prefix"
+                      type="text"
+                      required
+                      class="theme-input-affix__input"
+                      placeholder="如 marketing"
+                      autocomplete="off"
+                      spellcheck="false"
+                      data-domain-input-field
+                    />
+                    <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
+                    <input type="hidden" name="host" data-domain-input-hidden />
+                  </div>
                 </div>
                 <div class="theme-field">
-                  <label for="code" class="theme-label">状态码</label>
-                  <input
-                    id="code"
-                    name="code"
-                    type="number"
-                    value="302"
-                    min="301"
-                    max="302"
-                    step="1"
-                    class="theme-input"
-                  />
+                  <label for="subdomain-code" class="theme-label">状态码</label>
+                  <select id="subdomain-code" name="code" class="theme-select">
+                    {% for option in subdomain_code_options %}
+                    <option value="{{ option }}" {% if option == 302 %}selected{% endif %}>{{ option }}</option>
+                    {% endfor %}
+                  </select>
                 </div>
                 <div class="theme-field theme-form__span-full">
                   <label for="target_url" class="theme-label">目标地址 *</label>
@@ -300,10 +276,10 @@
               </div>
               <div class="theme-form__footer">
                 <p class="theme-helper">
-                  表单调用 <code>POST /api/subdomains</code>，与外部接口保持一致。
+                  表单调用 <code>POST /api/subdomains</code>，子域前缀会自动补全为 .{{ base_domain }} 的完整域名。
                 </p>
                 <button type="submit" class="theme-button theme-button--solid">
-                  保存子域跳转
+                  保存子域
                 </button>
               </div>
             </form>
@@ -317,9 +293,9 @@
         </section>
         <section class="theme-card">
           <div class="theme-card__header">
-            <h2 class="theme-card__title">子域跳转列表</h2>
+            <h2 class="theme-card__title">子域列表</h2>
             <p class="theme-card__subtitle">
-              快速检索当前子域配置、跳转目标与状态码，可直接删除或进入编辑态。
+              快速查看子域、跳转目标与状态码，可直接复制链接、删除或进入编辑。
             </p>
           </div>
           <div

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -9,15 +9,20 @@
     >
       <div class="theme-form__grid theme-form__grid--two">
         <div class="theme-field">
-          <label for="code-{{ item.id }}" class="theme-label">短链编码</label>
-          <input
-            id="code-{{ item.id }}"
-            name="code"
-            type="text"
-            required
-            value="{{ item.code }}"
-            class="theme-input"
-          />
+          <label for="code-{{ item.id }}" class="theme-label">短链</label>
+          <div class="theme-input-affix">
+            <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_prefix }}</span>
+            <input
+              id="code-{{ item.id }}"
+              name="code"
+              type="text"
+              required
+              value="{{ item.code }}"
+              class="theme-input-affix__input"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
         </div>
         <div class="theme-field theme-form__span-full">
           <label for="target-{{ item.id }}" class="theme-label">目标地址</label>

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -3,7 +3,23 @@
   class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="theme-table__cell theme-table__cell--mono">{{ item.code }}</td>
+  <td class="theme-table__cell">
+    <button
+      type="button"
+      class="theme-copy"
+      data-copy-value="{{ short_link_prefix }}{{ item.code }}"
+      aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
+    >
+      <span class="theme-copy__text">{{ short_link_prefix }}{{ item.code }}</span>
+      <span class="theme-copy__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24">
+          <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+          <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+        </svg>
+      </span>
+      <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
+    </button>
+  </td>
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted">{{ item.target_url }}</td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
   <td class="theme-table__cell theme-table__cell--muted">

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -2,7 +2,7 @@
 <table class="theme-table">
   <thead>
     <tr>
-      <th scope="col">短链编码</th>
+      <th scope="col">短链</th>
       <th scope="col">目标地址</th>
       <th scope="col">访问次数</th>
       <th scope="col">创建时间</th>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -9,29 +9,45 @@
     >
       <div class="theme-form__grid theme-form__grid--three">
         <div class="theme-field">
-          <label for="host-{{ item.id }}" class="theme-label">Host</label>
-          <input
-            id="host-{{ item.id }}"
-            name="host"
-            type="text"
-            required
-            value="{{ item.host }}"
-            class="theme-input"
-          />
+          <label for="host-{{ item.id }}" class="theme-label">子域</label>
+          {% set domain_suffix = '' %}
+          {% set suffix = '' %}
+          {% if base_domain %}
+          {% set suffix = '.' ~ base_domain %}
+          {% if item.host.endswith(suffix) %}
+          {% set domain_suffix = base_domain %}
+          {% endif %}
+          {% endif %}
+          {% set host_ns = namespace(value=item.host) %}
+          {% if domain_suffix %}
+          {% set host_ns.value = item.host[: item.host|length - ('.' ~ domain_suffix)|length] %}
+          {% endif %}
+          <div
+            class="theme-input-affix"
+            data-domain-input
+            data-domain-suffix="{{ domain_suffix }}"
+          >
+            <input
+              id="host-{{ item.id }}"
+              type="text"
+              required
+              value="{{ host_ns.value }}"
+              class="theme-input-affix__input"
+              autocomplete="off"
+              spellcheck="false"
+              data-domain-input-field
+            />
+            <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
+            <input type="hidden" name="host" value="{{ item.host }}" data-domain-input-hidden />
+          </div>
         </div>
         <div class="theme-field">
           <label for="code-{{ item.id }}" class="theme-label">状态码</label>
-          <input
-            id="code-{{ item.id }}"
-            name="code"
-            type="number"
-            min="301"
-            max="302"
-            step="1"
-            required
-            value="{{ item.code }}"
-            class="theme-input"
-          />
+          <select id="code-{{ item.id }}" name="code" class="theme-select" required>
+            {% for option in subdomain_code_options %}
+            <option value="{{ option }}" {% if option == item.code %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+          </select>
         </div>
         <div class="theme-field theme-form__span-full">
           <label for="target-{{ item.id }}" class="theme-label">目标地址</label>

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -3,7 +3,23 @@
   class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="theme-table__cell theme-table__cell--mono">{{ item.host }}</td>
+  <td class="theme-table__cell">
+    <button
+      type="button"
+      class="theme-copy"
+      data-copy-value="https://{{ item.host }}"
+      aria-label="复制子域 https://{{ item.host }}"
+    >
+      <span class="theme-copy__text">https://{{ item.host }}</span>
+      <span class="theme-copy__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24">
+          <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+          <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+        </svg>
+      </span>
+      <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
+    </button>
+  </td>
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted">{{ item.target_url }}</td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.code }}</td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
@@ -27,7 +43,7 @@
         hx-delete="/api/subdomains/{{ item.id }}"
         hx-target="#subdomain-feedback"
         hx-swap="innerHTML"
-        hx-confirm="确认删除该子域跳转？"
+        hx-confirm="确认删除该子域？"
         data-success-event="refresh-subdomains"
       >
         删除

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -2,7 +2,7 @@
 <table class="theme-table">
   <thead>
     <tr>
-      <th scope="col">Host</th>
+      <th scope="col">子域</th>
       <th scope="col">目标地址</th>
       <th scope="col">状态码</th>
       <th scope="col">访问次数</th>
@@ -18,6 +18,6 @@
 </table>
 {% else %}
 <div class="theme-table__empty">
-  暂无子域跳转规则，可通过上方表单或 <code>/api/subdomains</code> 接口创建。
+  暂无子域配置，可通过上方表单或 <code>/api/subdomains</code> 接口创建。
 </div>
 {% endif %}

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -19,15 +19,20 @@
     <script>
       (function () {
         var fallback = "aurora";
+        var supported = ["aurora", "nebula"];
         try {
           if (typeof window !== "undefined" && window.localStorage) {
             var stored = window.localStorage.getItem("yetla-admin-theme");
-            if (stored) {
+            if (stored && supported.indexOf(stored) !== -1) {
               fallback = stored;
             }
           }
         } catch (error) {
           /* ignore storage errors */
+        }
+
+        if (supported.indexOf(fallback) === -1) {
+          fallback = "aurora";
         }
 
         try {
@@ -87,7 +92,10 @@
         --theme-scrollbar: rgba(79, 70, 229, 0.35);
         --theme-preview-aurora: linear-gradient(135deg, rgba(99, 102, 241, 0.35), rgba(56, 189, 248, 0.35));
         --theme-preview-nebula: linear-gradient(135deg, rgba(14, 165, 233, 0.3), rgba(99, 102, 241, 0.34));
-        --theme-preview-noir: linear-gradient(135deg, rgba(15, 23, 42, 0.35), rgba(239, 68, 68, 0.28));
+        --theme-input-addon-border: rgba(148, 163, 184, 0.28);
+        --theme-copy-icon: rgba(148, 163, 184, 0.55);
+        --theme-copy-icon-active: rgba(99, 102, 241, 0.95);
+        --theme-copy-feedback: rgba(79, 70, 229, 0.95);
       }
 
       :root[data-theme="nebula"] {
@@ -127,42 +135,10 @@
         --theme-tab-active-bg: rgba(129, 140, 248, 0.28);
         --theme-tab-active-text: #e0e7ff;
         --theme-scrollbar: rgba(125, 211, 252, 0.45);
-      }
-
-      :root[data-theme="noir"] {
-        color-scheme: light;
-        --theme-page: linear-gradient(160deg, #0f172a 0%, #f8fafc 52%, #f1f5f9 100%);
-        --theme-page-overlay: radial-gradient(circle at 10% 15%, rgba(239, 68, 68, 0.15), transparent 55%);
-        --theme-text-primary: #111827;
-        --theme-text-secondary: #374151;
-        --theme-muted: #475569;
-        --theme-primary: #ef4444;
-        --theme-primary-strong: #dc2626;
-        --theme-on-primary: #fff5f5;
-        --theme-hero-bg: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(239, 68, 68, 0.72));
-        --theme-hero-border: rgba(255, 255, 255, 0.22);
-        --theme-hero-text: #f8fafc;
-        --theme-surface: rgba(255, 255, 255, 0.84);
-        --theme-surface-strong: rgba(255, 255, 255, 0.94);
-        --theme-surface-border: rgba(15, 23, 42, 0.12);
-        --theme-card-header-bg: rgba(248, 250, 252, 0.72);
-        --theme-input-bg: rgba(255, 255, 255, 0.92);
-        --theme-input-border: rgba(148, 163, 184, 0.35);
-        --theme-input-focus-border: rgba(239, 68, 68, 0.7);
-        --theme-input-focus-shadow: 0 0 0 4px rgba(239, 68, 68, 0.14);
-        --theme-button-border: rgba(17, 24, 39, 0.16);
-        --theme-button-ghost-bg: rgba(17, 24, 39, 0.08);
-        --theme-button-ghost-hover-bg: rgba(17, 24, 39, 0.12);
-        --theme-table-head-bg: rgba(248, 250, 252, 0.88);
-        --theme-table-row-hover: rgba(15, 23, 42, 0.06);
-        --theme-pill-bg: rgba(17, 24, 39, 0.12);
-        --theme-pill-text: #111827;
-        --theme-tab-bg: rgba(255, 255, 255, 0.72);
-        --theme-tab-border: rgba(17, 24, 39, 0.12);
-        --theme-tab-hover-bg: rgba(17, 24, 39, 0.12);
-        --theme-tab-active-bg: rgba(239, 68, 68, 0.16);
-        --theme-tab-active-text: #b91c1c;
-        --theme-scrollbar: rgba(239, 68, 68, 0.35);
+        --theme-input-addon-border: rgba(59, 130, 246, 0.22);
+        --theme-copy-icon: rgba(148, 163, 184, 0.65);
+        --theme-copy-icon-active: rgba(56, 189, 248, 0.95);
+        --theme-copy-feedback: #bae6fd;
       }
 
       body.theme-body {
@@ -208,6 +184,87 @@
         color: var(--theme-hero-text);
       }
 
+      .theme-hero__top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1.5rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.5rem;
+      }
+
+      .theme-theme-switch {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.35rem 0.4rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.28);
+        background: rgba(15, 23, 42, 0.2);
+        backdrop-filter: blur(12px);
+        flex-shrink: 0;
+      }
+
+      .theme-toggle {
+        width: 2.25rem;
+        height: 2.25rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
+        border: none;
+        background: transparent;
+        color: rgba(255, 255, 255, 0.85);
+        cursor: pointer;
+        transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+          transform 0.2s ease;
+      }
+
+      .theme-toggle svg {
+        width: 1.15rem;
+        height: 1.15rem;
+        stroke: currentColor;
+        stroke-width: 1.6;
+        fill: none;
+      }
+
+      .theme-toggle:hover,
+      .theme-toggle:focus-visible {
+        background: rgba(255, 255, 255, 0.18);
+        transform: translateY(-1px);
+      }
+
+      .theme-toggle:focus-visible {
+        outline: 2px solid rgba(255, 255, 255, 0.45);
+        outline-offset: 2px;
+      }
+
+      .theme-toggle.is-active {
+        background: rgba(255, 255, 255, 0.95);
+        color: var(--theme-primary);
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+      }
+
+      :root[data-theme="nebula"] .theme-theme-switch {
+        border-color: rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.45);
+      }
+
+      :root[data-theme="nebula"] .theme-toggle {
+        color: rgba(226, 232, 240, 0.88);
+      }
+
+      :root[data-theme="nebula"] .theme-toggle:hover,
+      :root[data-theme="nebula"] .theme-toggle:focus-visible {
+        background: rgba(56, 189, 248, 0.22);
+      }
+
+      :root[data-theme="nebula"] .theme-toggle.is-active {
+        background: rgba(56, 189, 248, 0.95);
+        color: #041023;
+        box-shadow: 0 12px 24px rgba(14, 116, 144, 0.35);
+      }
+
       .theme-hero__inner::after {
         content: "";
         position: absolute;
@@ -218,6 +275,18 @@
         filter: blur(0px);
         opacity: 0.65;
         pointer-events: none;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
       }
 
       .theme-hero__meta {
@@ -231,7 +300,13 @@
         font-size: 0.85rem;
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        margin-bottom: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .theme-hero__heading {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
       }
 
       .theme-hero__title {
@@ -330,10 +405,6 @@
 
       .theme-preview-card[data-theme-option="nebula"]::before {
         background: var(--theme-preview-nebula);
-      }
-
-      .theme-preview-card[data-theme-option="noir"]::before {
-        background: var(--theme-preview-noir);
       }
 
       .theme-preview-card:hover,
@@ -442,14 +513,6 @@
 
       .theme-preview-card[data-theme-option="nebula"] .theme-preview-button--ghost {
         background: rgba(129, 140, 248, 0.28);
-      }
-
-      .theme-preview-card[data-theme-option="noir"] .theme-preview-button {
-        background: rgba(239, 68, 68, 0.24);
-      }
-
-      .theme-preview-card[data-theme-option="noir"] .theme-preview-button--ghost {
-        background: rgba(15, 23, 42, 0.2);
       }
 
       .theme-preview-card__actions {
@@ -639,6 +702,64 @@
         box-shadow: var(--theme-input-focus-shadow);
       }
 
+      .theme-input-affix {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--theme-input-border);
+        background: var(--theme-input-bg);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+        transition: border-color 0.25s ease, box-shadow 0.25s ease,
+          background 0.25s ease;
+      }
+
+      :root[data-theme="nebula"] .theme-input-affix {
+        box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18);
+      }
+
+      .theme-input-affix:focus-within {
+        border-color: var(--theme-input-focus-border);
+        box-shadow: var(--theme-input-focus-shadow);
+      }
+
+      .theme-input-affix__addon {
+        display: inline-flex;
+        align-items: center;
+        padding: 0 0.85rem;
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        color: var(--theme-muted);
+        white-space: nowrap;
+      }
+
+      .theme-input-affix__addon--prefix {
+        border-right: 1px solid var(--theme-input-addon-border);
+      }
+
+      .theme-input-affix__addon--suffix {
+        border-left: 1px solid var(--theme-input-addon-border);
+      }
+
+      .theme-input-affix__input {
+        flex: 1;
+        min-width: 0;
+        border: none;
+        background: transparent;
+        color: var(--theme-text-primary);
+        font-size: 0.95rem;
+        padding: 0.75rem 0.95rem;
+      }
+
+      .theme-input-affix__input:focus,
+      .theme-input-affix__input:focus-visible {
+        outline: none;
+      }
+
+      .theme-input-affix__input::placeholder {
+        color: var(--theme-muted);
+      }
+
       .theme-helper {
         font-size: 0.85rem;
         color: var(--theme-muted);
@@ -781,6 +902,73 @@
         gap: 0.75rem;
       }
 
+      .theme-copy {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        background: transparent;
+        border: none;
+        color: var(--theme-text-primary);
+        font: inherit;
+        cursor: pointer;
+        padding: 0;
+        position: relative;
+        transition: color 0.2s ease;
+      }
+
+      .theme-copy:hover,
+      .theme-copy:focus-visible {
+        color: var(--theme-primary-strong);
+      }
+
+      .theme-copy:focus-visible {
+        outline: 2px solid var(--theme-primary-strong);
+        outline-offset: 2px;
+      }
+
+      .theme-copy__text {
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+      }
+
+      .theme-copy__icon {
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .theme-copy__icon svg {
+        width: 1rem;
+        height: 1rem;
+        stroke: var(--theme-copy-icon);
+        stroke-width: 1.6;
+        fill: none;
+        transition: stroke 0.2s ease;
+      }
+
+      .theme-copy:hover .theme-copy__icon svg,
+      .theme-copy:focus-visible .theme-copy__icon svg,
+      .theme-copy.is-copied .theme-copy__icon svg {
+        stroke: var(--theme-copy-icon-active);
+      }
+
+      .theme-copy__feedback {
+        position: absolute;
+        left: 0;
+        bottom: -1.4rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--theme-copy-feedback);
+        opacity: 0;
+        transform: translateY(4px);
+        transition: opacity 0.2s ease, transform 0.2s ease;
+        pointer-events: none;
+      }
+
+      .theme-copy.is-copied .theme-copy__feedback {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
       .theme-table__empty {
         padding: 2.5rem;
         text-align: center;
@@ -809,12 +997,6 @@
         border: 1px solid rgba(56, 189, 248, 0.2);
         font-size: 0.9rem;
         line-height: 1.6;
-      }
-
-      :root[data-theme="noir"] .theme-tagline {
-        background: rgba(17, 24, 39, 0.08);
-        color: #111827;
-        border-color: rgba(17, 24, 39, 0.12);
       }
 
       :root[data-theme="nebula"] .theme-tagline {
@@ -922,8 +1104,37 @@
   >
     <header class="theme-hero">
       <div class="theme-hero__inner">
-        <div class="theme-hero__meta">Yet.la Platform</div>
-        <h1 class="theme-hero__title">Yet.la 管理后台</h1>
+        <div class="theme-hero__top">
+          <div class="theme-hero__heading">
+            <div class="theme-hero__meta">Yet.la Platform</div>
+            <h1 class="theme-hero__title">Yet.la 管理后台</h1>
+          </div>
+          <div class="theme-theme-switch" role="group" aria-label="主题切换">
+            <button
+              type="button"
+              class="theme-toggle"
+              data-theme-toggle="aurora"
+              aria-pressed="false"
+            >
+              <span class="sr-only">切换到亮色主题</span>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="12" cy="12" r="5"></circle>
+                <path d="M12 1v2m0 18v2m11-11h-2M3 12H1m16.95-6.95-1.41 1.41M8.46 17.54l-1.41 1.41M17.54 17.54l-1.41-1.41M7.05 7.05 5.64 5.64"></path>
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="theme-toggle"
+              data-theme-toggle="nebula"
+              aria-pressed="false"
+            >
+              <span class="sr-only">切换到暗色主题</span>
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
         <p class="theme-hero__subtitle">
           通过多套主题风格快速预览、创建和管理短链与子域跳转配置，保持团队品牌体验的统一与时尚。
         </p>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -1,7 +1,11 @@
 """HTML views for the administrative dashboard."""
 from __future__ import annotations
 
+import os
+import secrets
+import string
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse
@@ -11,6 +15,13 @@ from sqlalchemy.orm import Session
 
 from .deps import get_db
 from .models import ShortLink, SubdomainRedirect
+
+DEFAULT_BASE_DOMAIN = "yet.la"
+SHORT_CODE_LENGTH = int(os.getenv("SHORT_CODE_LEN", "6"))
+ENV_BASE_DOMAIN = os.getenv("BASE_DOMAIN", "").strip().lower()
+EFFECTIVE_BASE_DOMAIN = ENV_BASE_DOMAIN or DEFAULT_BASE_DOMAIN
+BASE_URL = f"https://{EFFECTIVE_BASE_DOMAIN}".rstrip("/")
+SHORT_LINK_PREFIX = f"{BASE_URL}/"
 
 TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 
@@ -29,6 +40,29 @@ def _load_subdomains(db: Session) -> list[SubdomainRedirect]:
     )
 
 
+def _generate_short_link_suggestion(db: Session, length: int = SHORT_CODE_LENGTH) -> str:
+    """Generate a random short link code suggestion that does not clash with existing ones."""
+
+    alphabet = string.ascii_letters + string.digits
+    attempts = max(length * 2, 10)
+    for _ in range(attempts):
+        candidate = "".join(secrets.choice(alphabet) for _ in range(length))
+        exists = db.scalar(select(ShortLink.id).where(ShortLink.code == candidate))
+        if not exists:
+            return candidate
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _base_context(request: Request) -> dict[str, Any]:
+    return {
+        "request": request,
+        "base_domain": EFFECTIVE_BASE_DOMAIN,
+        "base_url": BASE_URL,
+        "short_link_prefix": SHORT_LINK_PREFIX,
+        "short_code_length": SHORT_CODE_LENGTH,
+    }
+
+
 @router.get("/admin", response_class=HTMLResponse)
 def admin_dashboard(
     request: Request,
@@ -42,15 +76,17 @@ def admin_dashboard(
     short_links = _load_short_links(db)
     subdomains = _load_subdomains(db)
 
-    return templates.TemplateResponse(
-        "admin/index.html",
+    context = _base_context(request)
+    context.update(
         {
-            "request": request,
             "active_tab": active_tab,
             "short_links": short_links,
             "subdomains": subdomains,
-        },
+            "short_code_suggestion": _generate_short_link_suggestion(db),
+            "subdomain_code_options": [302, 301],
+        }
     )
+    return templates.TemplateResponse("admin/index.html", context)
 
 
 @router.get("/admin/links/count", response_class=HTMLResponse)
@@ -61,10 +97,9 @@ def short_link_count(
     """Return a small fragment containing the current short link count."""
 
     short_links = _load_short_links(db)
-    return templates.TemplateResponse(
-        "admin/partials/link_count.html",
-        {"request": request, "count": len(short_links)},
-    )
+    context = _base_context(request)
+    context.update({"count": len(short_links)})
+    return templates.TemplateResponse("admin/partials/link_count.html", context)
 
 
 @router.get("/admin/links/table", response_class=HTMLResponse)
@@ -75,10 +110,9 @@ def short_link_table(
     """Return the short link table fragment for HTMX swaps."""
 
     short_links = _load_short_links(db)
-    return templates.TemplateResponse(
-        "admin/partials/link_table.html",
-        {"request": request, "short_links": short_links},
-    )
+    context = _base_context(request)
+    context.update({"short_links": short_links})
+    return templates.TemplateResponse("admin/partials/link_table.html", context)
 
 
 @router.get("/admin/links/{link_id}/row", response_class=HTMLResponse)
@@ -93,10 +127,9 @@ def short_link_row(
     if short_link is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="短链接不存在")
 
-    return templates.TemplateResponse(
-        "admin/partials/link_row.html",
-        {"request": request, "item": short_link},
-    )
+    context = _base_context(request)
+    context.update({"item": short_link})
+    return templates.TemplateResponse("admin/partials/link_row.html", context)
 
 
 @router.get("/admin/links/{link_id}/edit", response_class=HTMLResponse)
@@ -111,10 +144,9 @@ def short_link_edit_row(
     if short_link is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="短链接不存在")
 
-    return templates.TemplateResponse(
-        "admin/partials/link_edit_row.html",
-        {"request": request, "item": short_link},
-    )
+    context = _base_context(request)
+    context.update({"item": short_link})
+    return templates.TemplateResponse("admin/partials/link_edit_row.html", context)
 
 
 @router.get("/admin/subdomains/count", response_class=HTMLResponse)
@@ -125,10 +157,9 @@ def subdomain_count(
     """Return the current subdomain redirect count fragment."""
 
     subdomains = _load_subdomains(db)
-    return templates.TemplateResponse(
-        "admin/partials/subdomain_count.html",
-        {"request": request, "count": len(subdomains)},
-    )
+    context = _base_context(request)
+    context.update({"count": len(subdomains)})
+    return templates.TemplateResponse("admin/partials/subdomain_count.html", context)
 
 
 @router.get("/admin/subdomains/table", response_class=HTMLResponse)
@@ -139,10 +170,9 @@ def subdomain_table(
     """Return the subdomain table fragment for HTMX swaps."""
 
     subdomains = _load_subdomains(db)
-    return templates.TemplateResponse(
-        "admin/partials/subdomain_table.html",
-        {"request": request, "subdomains": subdomains},
-    )
+    context = _base_context(request)
+    context.update({"subdomains": subdomains})
+    return templates.TemplateResponse("admin/partials/subdomain_table.html", context)
 
 
 @router.get("/admin/subdomains/{redirect_id}/row", response_class=HTMLResponse)
@@ -157,10 +187,9 @@ def subdomain_row(
     if redirect is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="子域跳转不存在")
 
-    return templates.TemplateResponse(
-        "admin/partials/subdomain_row.html",
-        {"request": request, "item": redirect},
-    )
+    context = _base_context(request)
+    context.update({"item": redirect})
+    return templates.TemplateResponse("admin/partials/subdomain_row.html", context)
 
 
 @router.get("/admin/subdomains/{redirect_id}/edit", response_class=HTMLResponse)
@@ -175,7 +204,6 @@ def subdomain_edit_row(
     if redirect is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="子域跳转不存在")
 
-    return templates.TemplateResponse(
-        "admin/partials/subdomain_edit_row.html",
-        {"request": request, "item": redirect},
-    )
+    context = _base_context(request)
+    context.update({"item": redirect})
+    return templates.TemplateResponse("admin/partials/subdomain_edit_row.html", context)

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -120,7 +120,7 @@ def test_admin_short_link_partials(client: "SimpleClient") -> None:
 
     table = client.get("/admin/links/table", auth=ADMIN_AUTH)
     assert table.status_code == 200
-    assert "短链编码" in table.text
+    assert "<th scope=\"col\">短链</th>" in table.text
 
     count = client.get("/admin/links/count", auth=ADMIN_AUTH)
     assert count.status_code == 200


### PR DESCRIPTION
## Summary
- replace the Noir theme with Aurora/Nebula light-dark toggle controls in the admin dashboard shell
- update short-link creation/editing to expose the fixed https://yet.la/ prefix, random defaults, and copyable full URLs
- streamline subdomain forms to capture only prefixes, append the base domain automatically, and add copy helpers plus status dropdowns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e075baf094832fb710c93bd2146b30