### PR TITLE
Add session login and align admin dashboard layout

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -4,17 +4,32 @@ from __future__ import annotations
 import os
 import secrets
 from typing import Generator
+from urllib.parse import quote
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from sqlalchemy.orm import Session
 
 from .models import SessionLocal
+from .session import get_session
 
 ADMIN_USER = os.getenv("ADMIN_USER", "admin")
 ADMIN_PASS = os.getenv("ADMIN_PASS", "admin")
 
-security = HTTPBasic()
+security = HTTPBasic(auto_error=False)
+
+
+def _authenticate(username: str, password: str) -> tuple[bool, str | None]:
+    """Validate credential pairs and return status plus failure reason."""
+
+    safe_username = username or ""
+    safe_password = password or ""
+
+    if not secrets.compare_digest(safe_username, ADMIN_USER or ""):
+        return False, "username"
+    if not secrets.compare_digest(safe_password, ADMIN_PASS or ""):
+        return False, "password"
+    return True, None
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -27,18 +42,61 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
-def require_basic_auth(credentials: HTTPBasicCredentials = Depends(security)) -> None:
+def require_basic_auth(credentials: HTTPBasicCredentials | None = Depends(security)) -> None:
     """Enforce HTTP Basic authentication using environment credentials."""
 
-    username = credentials.username or ""
-    password = credentials.password or ""
-
-    correct_username = secrets.compare_digest(username, ADMIN_USER or "")
-    correct_password = secrets.compare_digest(password, ADMIN_PASS or "")
-
-    if not (correct_username and correct_password):
+    if credentials is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="认证失败",
             headers={"WWW-Authenticate": "Basic"},
         )
+
+    ok, _ = _authenticate(credentials.username, credentials.password)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="认证失败",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+
+
+def require_admin_auth(
+    request: Request,
+    credentials: HTTPBasicCredentials | None = Depends(security),
+) -> None:
+    """Allow either session-based login or HTTP Basic credentials."""
+
+    session = get_session(request)
+    if session.get("is_authenticated"):
+        return
+
+    if credentials is not None:
+        require_basic_auth(credentials)
+        return
+
+    accepts_html = "text/html" in (request.headers.get("accept") or "")
+    if accepts_html or request.url.path.startswith("/admin"):
+        target = request.url.path
+        if request.url.query:
+            target = f"{target}?{request.url.query}"
+        redirect = "/admin/login"
+        if target and target != "/admin/login":
+            redirect = f"/admin/login?next={quote(target, safe='')}"
+        raise HTTPException(
+            status.HTTP_303_SEE_OTHER,
+            detail="未登录",
+            headers={"Location": redirect},
+        )
+
+    raise HTTPException(
+        status.HTTP_401_UNAUTHORIZED,
+        detail="未登录",
+        headers={"WWW-Authenticate": "Basic"},
+    )
+
+
+def validate_credentials(username: str, password: str) -> tuple[bool, str | None]:
+    """Expose credential validation for the login flow."""
+
+    return _authenticate(username, password)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from .deps import get_db, require_basic_auth
+from .deps import get_db, require_admin_auth
 from .models import Base, ShortLink, SubdomainRedirect, engine, ensure_subdomain_hits_column
 from .schemas import (
     ShortLink as ShortLinkSchema,
@@ -41,15 +41,15 @@ app = FastAPI(
 )
 
 
-from .views import (
+from .views import (  # noqa: E402  pylint: disable=wrong-import-position
     router as admin_router,
     templates as admin_templates,
-)  # noqa: E402  pylint: disable=wrong-import-position
+)
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
-app.include_router(admin_router, dependencies=[Depends(require_basic_auth)])
+app.include_router(admin_router)
 
 
 @app.on_event("startup")
@@ -289,7 +289,7 @@ def list_routes(db: Session = Depends(get_db)) -> list[SubdomainRedirect]:
 @app.get(
     "/api/links",
     response_model=list[ShortLinkSchema],
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 def list_short_links(db: Session = Depends(get_db)) -> list[ShortLink]:
     """列出所有短链接。"""
@@ -302,7 +302,7 @@ def list_short_links(db: Session = Depends(get_db)) -> list[ShortLink]:
     "/api/links",
     response_model=ShortLinkSchema,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 async def create_short_link(
     request: Request,
@@ -343,7 +343,7 @@ async def create_short_link(
 
 @app.delete(
     "/api/links/{link_id}",
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 def delete_short_link(
     link_id: int,
@@ -377,7 +377,7 @@ def delete_short_link(
 @app.put(
     "/api/links/{link_id}",
     response_model=ShortLinkSchema,
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 async def update_short_link(
     link_id: int,
@@ -427,7 +427,7 @@ async def update_short_link(
 @app.get(
     "/api/subdomains",
     response_model=list[SubdomainRedirectSchema],
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 def list_subdomains(db: Session = Depends(get_db)) -> list[SubdomainRedirect]:
     """列出所有子域跳转规则。"""
@@ -442,7 +442,7 @@ def list_subdomains(db: Session = Depends(get_db)) -> list[SubdomainRedirect]:
     "/api/subdomains",
     response_model=SubdomainRedirectSchema,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 async def create_subdomain(
     request: Request,
@@ -481,7 +481,7 @@ async def create_subdomain(
 
 @app.delete(
     "/api/subdomains/{redirect_id}",
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 def delete_subdomain(
     redirect_id: int,
@@ -516,7 +516,7 @@ def delete_subdomain(
 @app.put(
     "/api/subdomains/{redirect_id}",
     response_model=SubdomainRedirectSchema,
-    dependencies=[Depends(require_basic_auth)],
+    dependencies=[Depends(require_admin_auth)],
 )
 async def update_subdomain(
     redirect_id: int,

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -1,0 +1,77 @@
+"""Lightweight signed-cookie session helpers for the admin interface."""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+
+from fastapi import Request, Response
+
+SESSION_COOKIE_NAME = "yetla_session"
+_SESSION_SECRET = os.getenv("SESSION_SECRET", os.getenv("ADMIN_PASS", "yetla-session")).encode("utf-8")
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _b64decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _sign(payload: bytes) -> bytes:
+    return hmac.new(_SESSION_SECRET, payload, hashlib.sha256).digest()
+
+
+def serialize_session(data: dict[str, Any]) -> str:
+    payload = json.dumps(data, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    signature = _sign(payload)
+    return f"{_b64encode(payload)}.{_b64encode(signature)}"
+
+
+def deserialize_session(token: str | None) -> dict[str, Any]:
+    if not token:
+        return {}
+    try:
+        payload_b64, signature_b64 = token.split(".", 1)
+        payload = _b64decode(payload_b64)
+        signature = _b64decode(signature_b64)
+    except (ValueError, binascii.Error):
+        return {}
+    expected_signature = _sign(payload)
+    if not hmac.compare_digest(signature, expected_signature):
+        return {}
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def get_session(request: Request) -> dict[str, Any]:
+    cached = getattr(request.state, "_yetla_session", None)
+    if cached is not None:
+        return cached
+    session = deserialize_session(request.cookies.get(SESSION_COOKIE_NAME))
+    request.state._yetla_session = session
+    return session
+
+
+def set_session(response: Response, request: Request, data: dict[str, Any]) -> None:
+    request.state._yetla_session = data
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        serialize_session(data),
+        httponly=True,
+        samesite="lax",
+        path="/",
+    )
+
+
+def clear_session(response: Response, request: Request) -> None:
+    request.state._yetla_session = {}
+    response.delete_cookie(SESSION_COOKIE_NAME, path="/")

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -9,27 +9,26 @@
         class="theme-tab {% if active_tab == 'links' %}is-active{% endif %}"
       >
         <span class="theme-tab__dot"></span>
-        短链 (
+        短链
         <span
+          class="theme-tab__count"
           id="short-link-count"
           hx-get="/admin/links/count"
           hx-trigger="load, refresh-links from:body"
           hx-swap="outerHTML"
         >
-          {{ short_links|length }}
+          ({{ short_links|length }})
         </span>
-        )
       </a>
       <a
         href="?tab=subdomains"
         class="theme-tab {% if active_tab == 'subdomains' %}is-active{% endif %}"
       >
         <span class="theme-tab__dot"></span>
-        子域 (
+        子域
         {% with count=subdomains|length %}
         {% include "admin/partials/subdomain_count.html" %}
         {% endwith %}
-        )
       </a>
     </nav>
     <div class="theme-shell__body">

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="theme-layout">
+  <section class="theme-shell">
+    <div class="theme-shell__body theme-shell__body--center">
+      <section class="theme-card theme-card--narrow">
+        <div class="theme-card__header">
+          <h2 class="theme-card__title">登录 yet.la 短链子域管理后台</h2>
+          <p class="theme-card__subtitle">输入管理员账号与密码以继续管理短链与子域。</p>
+        </div>
+        <div class="theme-card__body">
+          <form
+            class="theme-form"
+            action="/admin/login{% if redirect_target %}?next={{ redirect_target|urlencode }}{% endif %}"
+            method="post"
+          >
+            <div class="theme-field">
+              <label for="username" class="theme-label">账号 *</label>
+              <input
+                id="username"
+                name="username"
+                type="text"
+                required
+                class="theme-input"
+                autocomplete="username"
+                spellcheck="false"
+                value="{{ username_value }}"
+              />
+            </div>
+            <div class="theme-field">
+              <label for="password" class="theme-label">密码 *</label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                class="theme-input"
+                autocomplete="current-password"
+              />
+            </div>
+            <div class="theme-form__footer theme-form__footer--center">
+              <button type="submit" class="theme-button theme-button--solid theme-button--block">
+                登录
+              </button>
+            </div>
+          </form>
+          {% if login_error %}
+          <div class="theme-login-feedback" role="alert">{{ login_error }}</div>
+          {% endif %}
+        </div>
+      </section>
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/backend/app/templates/admin/partials/link_count.html
+++ b/backend/app/templates/admin/partials/link_count.html
@@ -1,8 +1,9 @@
 <span
+  class="theme-tab__count"
   id="short-link-count"
   hx-get="/admin/links/count"
   hx-trigger="load, refresh-links from:body"
   hx-swap="outerHTML"
 >
-  {{ count }}
+  ({{ count }})
 </span>

--- a/backend/app/templates/admin/partials/subdomain_count.html
+++ b/backend/app/templates/admin/partials/subdomain_count.html
@@ -1,8 +1,9 @@
 <span
+  class="theme-tab__count"
   id="subdomain-count"
   hx-get="/admin/subdomains/count"
   hx-trigger="load, refresh-subdomains from:body"
   hx-swap="outerHTML"
 >
-  {{ count }}
+  ({{ count }})
 </span>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -53,6 +53,8 @@
         --radius-sm: 12px;
         --shadow-soft: 0 24px 45px rgba(15, 23, 42, 0.1);
         --shadow-glow: 0 20px 45px rgba(56, 189, 248, 0.18);
+        --theme-container-max: 1120px;
+        --theme-container-padding: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
         --theme-page: radial-gradient(circle at 0% -10%, #ecf1ff 0%, #f9fcff 40%, #f2f4ff 100%);
         --theme-page-overlay: radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.12), transparent 60%);
         --theme-text-primary: #111827;
@@ -174,8 +176,8 @@
       .theme-hero__inner {
         position: relative;
         margin: 0 auto;
-        max-width: 1120px;
-        padding: 1.1rem 2.25rem;
+        width: min(100%, calc(var(--theme-container-max) + var(--theme-container-padding) * 2));
+        padding: 1.1rem var(--theme-container-padding);
         border-radius: var(--radius-lg);
         background: var(--theme-hero-bg);
         overflow: hidden;
@@ -362,15 +364,16 @@
       }
 
       .theme-main {
-        padding: 0 1.5rem 2.5rem;
+        padding: 0 var(--theme-container-padding) 2.5rem;
       }
 
       .theme-layout {
-        max-width: 1120px;
+        width: min(100%, calc(var(--theme-container-max) + var(--theme-container-padding) * 2));
         margin: 0 auto;
         display: flex;
         flex-direction: column;
         gap: 3rem;
+        box-sizing: border-box;
       }
 
       .theme-footer {
@@ -593,7 +596,7 @@
         display: flex;
         flex-wrap: wrap;
         gap: 0.75rem;
-        padding: 2.25rem 2.25rem 0;
+        padding: 2.25rem var(--theme-container-padding) 0;
       }
 
       .theme-tab {
@@ -620,6 +623,14 @@
         transition: transform 0.25s ease, background 0.25s ease;
       }
 
+      .theme-tab__count {
+        display: inline-flex;
+        align-items: center;
+        line-height: 1;
+        font-variant-numeric: tabular-nums;
+        margin-left: 0.1rem;
+      }
+
       .theme-tab:hover,
       .theme-tab:focus-visible {
         background: var(--theme-tab-hover-bg);
@@ -639,7 +650,14 @@
       }
 
       .theme-shell__body {
-        padding: 2.25rem;
+        padding: 2.25rem var(--theme-container-padding) 2.25rem;
+      }
+
+      .theme-shell__body--center {
+        display: flex;
+        justify-content: center;
+        padding-top: 3rem;
+        padding-bottom: 3rem;
       }
 
       .theme-stack {
@@ -654,6 +672,11 @@
         background: var(--theme-surface-strong);
         box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
         overflow: hidden;
+      }
+
+      .theme-card--narrow {
+        max-width: 420px;
+        width: 100%;
       }
 
       .theme-card__header {
@@ -850,6 +873,10 @@
         box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
       }
 
+      .theme-button--block {
+        width: 100%;
+      }
+
       .theme-button--solid:hover,
       .theme-button--solid:focus-visible {
         background: var(--theme-button-solid-hover);
@@ -880,10 +907,20 @@
 
       .theme-feedback {
         border-top: 1px solid var(--theme-surface-border);
-        padding: 1.35rem 2.25rem;
+        padding: 1.35rem var(--theme-container-padding);
         font-size: 0.9rem;
         color: var(--theme-text-secondary);
         background: rgba(255, 255, 255, 0.35);
+      }
+
+      .theme-login-feedback {
+        margin-top: 0.75rem;
+        padding: 0.9rem 1.1rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--theme-danger-border);
+        background: var(--theme-danger-bg);
+        color: var(--theme-danger-text);
+        font-size: 0.9rem;
       }
 
       .theme-table {
@@ -1146,18 +1183,13 @@
       });
     </script>
   </head>
-  {% set auth_header = request.headers.get("Authorization") if request else None %}
-  <body
-    class="theme-body"
-    {% if auth_header %}hx-headers='{{ {"Authorization": auth_header}|tojson }}'{% endif %}
-    {% if auth_header %}data-auth-header="{{ auth_header }}"{% endif %}
-  >
+  <body class="theme-body">
     <header class="theme-hero">
       <div class="theme-hero__inner">
         <div class="theme-hero__top">
           <div class="theme-hero__heading">
             <div class="theme-hero__meta">yet.la Platform</div>
-            <h1 class="theme-hero__title">短链子域管理后台</h1>
+            <h1 class="theme-hero__title">yet.la 短链子域管理后台</h1>
           </div>
           <div class="theme-hero__actions">
             <div class="theme-theme-switch" role="group" aria-label="主题切换">
@@ -1185,12 +1217,15 @@
                 </svg>
               </button>
             </div>
+            {% if show_logout_button %}
             <a
               class="theme-button theme-button--ghost theme-button--logout"
               href="/admin/logout"
+              onclick="return confirm('确认退出登录？')"
             >
               退出
             </a>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -14,6 +14,59 @@ def test_protected_endpoints_require_basic_auth(client: "SimpleClient") -> None:
 
 
 def test_admin_dashboard_requires_basic_auth(client: "SimpleClient") -> None:
-    response = client.get("/admin")
-    assert response.status_code == 401
-    assert response.headers["www-authenticate"] == "Basic"
+    response = client.get("/admin", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/admin/login")
+
+
+def test_login_flow_success(client: "SimpleClient") -> None:
+    response = client.get("/admin/login")
+    assert response.status_code == 200
+    assert "登录 yet.la 短链子域管理后台" in response.text
+
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": "admin"},
+    )
+    assert response.status_code == 200
+    assert "创建短链" in response.text
+
+    dashboard = client.get("/admin", follow_redirects=False)
+    assert dashboard.status_code == 200
+
+
+def test_login_flow_failure_feedback(client: "SimpleClient") -> None:
+    response = client.post(
+        "/admin/login",
+        data={"username": "wrong", "password": "admin"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 400
+    assert "账号错误" in response.text
+
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": "oops"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 400
+    assert "密码错误" in response.text
+
+
+def test_logout_clears_session(client: "SimpleClient") -> None:
+    client.post(
+        "/admin/login",
+        data={"username": "admin", "password": "admin"},
+    )
+
+    response = client.get("/admin/logout", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/admin/login")
+
+    login_page = client.get("/admin/login")
+    assert login_page.status_code == 200
+    assert "登录 yet.la 短链子域管理后台" in login_page.text
+
+    response = client.get("/admin", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/admin/login")


### PR DESCRIPTION
## Summary
- replace the admin basic-auth prompt with a themed login page backed by signed-cookie sessions and clearer logout handling
- align dashboard layout widths and tab counters with the hero card while updating the header copy to emphasize the yet.la branding
- harden admin htmx fallbacks and automated tests to cover the new authentication flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e08e4d9964832fb83f50b06f8f2b19