### PR TITLE
Fix logout session clearing and adjust admin layout alignment

### DIFF
--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -74,12 +74,9 @@ def set_session(response: Response, request: Request, data: dict[str, Any]) -> N
 
 def clear_session(response: Response, request: Request) -> None:
     request.state._yetla_session = {}
-    response.set_cookie(
+    response.delete_cookie(
         SESSION_COOKIE_NAME,
-        "",
         path="/",
-        max_age=0,
-        expires=0,
         httponly=True,
         samesite="lax",
     )

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -4,7 +4,7 @@
 <div class="theme-layout">
   <section class="theme-shell">
     <div class="theme-shell__body theme-shell__body--center">
-      <section class="theme-card theme-card--narrow theme-card--auth">
+      <section class="theme-card theme-card--narrow">
         <div class="theme-card__header">
           <h2 class="theme-card__title">登录 yet.la 短链子域管理后台</h2>
           <p class="theme-card__subtitle">输入管理员账号与密码以继续管理短链与子域。</p>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -627,8 +627,8 @@
 
       .theme-tab__count {
         display: inline-flex;
-        align-items: baseline;
-        align-self: baseline;
+        align-items: center;
+        align-self: center;
         line-height: 1.1;
         font-variant-numeric: tabular-nums;
         margin-left: 0.1rem;
@@ -682,28 +682,11 @@
         width: 100%;
       }
 
-      .theme-card--auth .theme-card__body {
-        align-items: center;
-      }
-
-      .theme-card--auth .theme-field,
-      .theme-card--auth .theme-form__footer,
-      .theme-card--auth .theme-login-feedback {
-        width: 100%;
-        max-width: 320px;
-        margin-left: auto;
-        margin-right: auto;
-      }
-
-      .theme-card--auth .theme-form__footer {
-        justify-content: center;
-      }
-
       .theme-field--constrained {
-        width: 100%;
-        max-width: 720px;
-        margin-left: auto;
+        width: min(100%, 720px);
+        margin-left: 0;
         margin-right: auto;
+        justify-self: start;
       }
 
       .theme-card__header {


### PR DESCRIPTION
## Summary
- ensure the admin logout route clears the session cookie so future visits require login
- revert the auth card width tweak and left-align constrained form fields
- align tab count badges with their labels for consistent presentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e09e6b2194832f81fd264df12fe8f1