### PR TITLE
Ensure admin logout clears sessions and refresh login styling

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -71,11 +71,15 @@ def require_admin_auth(
     if session.get("is_authenticated"):
         return
 
-    if credentials is not None:
+    accept_header = (request.headers.get("accept") or "").lower()
+    accepts_html = "text/html" in accept_header
+
+    if credentials is not None and (
+        not request.url.path.startswith("/admin") or not accepts_html
+    ):
         require_basic_auth(credentials)
         return
 
-    accepts_html = "text/html" in (request.headers.get("accept") or "")
     if accepts_html or request.url.path.startswith("/admin"):
         target = request.url.path
         if request.url.query:

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -5,13 +5,13 @@
   <section class="theme-shell">
     <div class="theme-shell__body theme-shell__body--center">
       <section class="theme-card theme-card--narrow">
-        <div class="theme-card__header">
+        <div class="theme-card__header theme-card__header--center">
           <h2 class="theme-card__title">登录 yet.la 短链子域管理后台</h2>
           <p class="theme-card__subtitle">输入管理员账号与密码以继续管理短链与子域。</p>
         </div>
         <div class="theme-card__body">
           <form
-            class="theme-form"
+            class="theme-form theme-form--login"
             action="/admin/login{% if redirect_target %}?next={{ redirect_target|urlencode }}{% endif %}"
             method="post"
           >

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}yet.la 短链子域管理后台{% endblock %}</title>
+    <link rel="icon" type="image/png" href="https://img.811777.xyz/i/2025/10/04/68e0a010486cf.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -341,10 +342,27 @@
         margin-bottom: 0.35rem;
       }
 
+      .theme-hero__brand {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.35rem 0.9rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.18);
+        backdrop-filter: blur(12px);
+        line-height: 0;
+      }
+
       .theme-hero__heading {
         display: flex;
         flex-direction: column;
         gap: 0.5rem;
+      }
+
+      .theme-hero__brand-logo {
+        display: block;
+        height: 44px;
+        width: auto;
       }
 
       .theme-hero__title {
@@ -584,6 +602,8 @@
         box-shadow: var(--shadow-soft);
         backdrop-filter: blur(16px);
         overflow: hidden;
+        width: min(100%, calc(var(--theme-container-max) + var(--theme-container-padding) * 2));
+        margin: 0 auto;
       }
 
       .theme-shell__banner {
@@ -627,8 +647,7 @@
 
       .theme-tab__count {
         display: inline-flex;
-        align-items: center;
-        align-self: center;
+        align-items: flex-end;
         line-height: 1.1;
         font-variant-numeric: tabular-nums;
         margin-left: 0.1rem;
@@ -696,6 +715,15 @@
         backdrop-filter: blur(12px);
       }
 
+      .theme-card__header--center {
+        text-align: center;
+      }
+
+      .theme-card__header--center .theme-card__subtitle {
+        margin-left: auto;
+        margin-right: auto;
+      }
+
       .theme-card__title {
         font-size: 1.2rem;
         font-weight: 600;
@@ -727,6 +755,35 @@
         display: flex;
         flex-direction: column;
         gap: 1.75rem;
+      }
+
+      .theme-form--login {
+        align-items: center;
+        text-align: center;
+      }
+
+      .theme-form--login .theme-field {
+        width: 100%;
+        max-width: 320px;
+        align-items: center;
+      }
+
+      .theme-form--login .theme-label {
+        width: 100%;
+        text-align: center;
+      }
+
+      .theme-form--login .theme-input {
+        max-width: 320px;
+        margin: 0 auto;
+      }
+
+      .theme-form--login .theme-form__footer {
+        width: 100%;
+      }
+
+      .theme-form--login .theme-button--block {
+        max-width: 320px;
       }
 
       .theme-form__grid {
@@ -931,6 +988,10 @@
         background: var(--theme-danger-bg);
         color: var(--theme-danger-text);
         font-size: 0.9rem;
+        text-align: center;
+        max-width: 320px;
+        margin-left: auto;
+        margin-right: auto;
       }
 
       .theme-table {
@@ -1198,7 +1259,14 @@
       <div class="theme-hero__inner">
         <div class="theme-hero__top">
           <div class="theme-hero__heading">
-            <div class="theme-hero__meta">yet.la Platform</div>
+            <div class="theme-hero__brand">
+              <img
+                src="https://img.811777.xyz/i/2025/10/04/68e0a00e3ab35.png"
+                alt="yet.la 平台标识"
+                class="theme-hero__brand-logo"
+              />
+              <span class="sr-only">yet.la Platform</span>
+            </div>
             <h1 class="theme-hero__title">yet.la 短链子域管理后台</h1>
           </div>
           <div class="theme-hero__actions">


### PR DESCRIPTION
## Summary
- prevent HTML admin pages from authenticating with cached HTTP Basic credentials so logout invalidates the session
- refresh the admin hero and login form styling, including centered fields, brand image, and favicon updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e0a2673084832fa63cc27055d7ad96