### PR TITLE
Adjust admin login layout spacing

### DIFF
--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -16,7 +16,10 @@
             method="post"
           >
             <div class="theme-field">
-              <label for="username" class="theme-label">账号 *</label>
+              <label for="username" class="theme-label">
+                <span class="theme-label__text">账号</span>
+                <span class="theme-label__marker">*</span>
+              </label>
               <input
                 id="username"
                 name="username"
@@ -29,7 +32,10 @@
               />
             </div>
             <div class="theme-field">
-              <label for="password" class="theme-label">密码 *</label>
+              <label for="password" class="theme-label">
+                <span class="theme-label__text">密码</span>
+                <span class="theme-label__marker">*</span>
+              </label>
               <input
                 id="password"
                 name="password"

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -648,9 +648,11 @@
       .theme-tab__count {
         display: inline-flex;
         align-items: flex-end;
-        line-height: 1.1;
+        line-height: 1;
         font-variant-numeric: tabular-nums;
         margin-left: 0.1rem;
+        position: relative;
+        top: 0.08rem;
       }
 
       .theme-tab:hover,
@@ -672,7 +674,7 @@
       }
 
       .theme-shell__body {
-        padding: 2.25rem var(--theme-container-padding) 2.25rem;
+        padding: 2.25rem 2.25rem 2.75rem;
       }
 
       .theme-shell__body--center {
@@ -764,17 +766,29 @@
 
       .theme-form--login .theme-field {
         width: 100%;
-        max-width: 320px;
+        max-width: 280px;
         align-items: center;
       }
 
       .theme-form--login .theme-label {
         width: 100%;
         text-align: center;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.4rem;
+      }
+
+      .theme-form--login .theme-label__text {
+        letter-spacing: 0.75em;
+      }
+
+      .theme-form--login .theme-label__marker {
+        letter-spacing: normal;
       }
 
       .theme-form--login .theme-input {
-        max-width: 320px;
+        max-width: 280px;
         margin: 0 auto;
       }
 
@@ -783,7 +797,7 @@
       }
 
       .theme-form--login .theme-button--block {
-        max-width: 320px;
+        max-width: 280px;
       }
 
       .theme-form__grid {


### PR DESCRIPTION
## Summary
- align the admin shell body width with the hero banner and lower the tab count badges
- increase spacing for the login labels and tighten the input/button widths
- update the login template markup to support the new label styling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e0a6cb7f58832f8d1f59632b9c4681