### PR TITLE
Adjust admin login layout

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -699,7 +699,7 @@
       }
 
       .theme-card--narrow {
-        max-width: 420px;
+        max-width: 520px;
         width: 100%;
       }
 
@@ -760,44 +760,41 @@
       }
 
       .theme-form--login {
-        align-items: center;
-        text-align: center;
+        align-items: stretch;
+        text-align: left;
       }
 
       .theme-form--login .theme-field {
         width: 100%;
-        max-width: 280px;
-        align-items: center;
+        max-width: none;
+        align-items: stretch;
       }
 
       .theme-form--login .theme-label {
         width: 100%;
-        text-align: center;
+        text-align: left;
         display: flex;
-        justify-content: center;
+        justify-content: flex-start;
         align-items: center;
         gap: 0.4rem;
       }
 
       .theme-form--login .theme-label__text {
-        letter-spacing: 0.75em;
-      }
-
-      .theme-form--login .theme-label__marker {
         letter-spacing: normal;
       }
 
       .theme-form--login .theme-input {
-        max-width: 280px;
-        margin: 0 auto;
+        max-width: none;
+        margin: 0;
       }
 
       .theme-form--login .theme-form__footer {
         width: 100%;
+        align-items: stretch;
       }
 
       .theme-form--login .theme-button--block {
-        max-width: 280px;
+        max-width: none;
       }
 
       .theme-form__grid {


### PR DESCRIPTION
## Summary
- widen the admin login card for a more spacious layout
- left-align the login form labels and inputs for better readability

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0a9323d70832f853f88896d55a787