### PR TITLE
Adjust admin layout width and login input sizing

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -54,7 +54,7 @@
         --radius-sm: 12px;
         --shadow-soft: 0 24px 45px rgba(15, 23, 42, 0.1);
         --shadow-glow: 0 20px 45px rgba(56, 189, 248, 0.18);
-        --theme-container-max: 1120px;
+        --theme-container-max: 1280px;
         --theme-container-padding: clamp(1.5rem, 1.5vw + 1rem, 2.25rem);
         --theme-page: radial-gradient(circle at 0% -10%, #ecf1ff 0%, #f9fcff 40%, #f2f4ff 100%);
         --theme-page-overlay: radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.12), transparent 60%);
@@ -766,7 +766,9 @@
 
       .theme-form--login .theme-field {
         width: 100%;
-        max-width: none;
+        max-width: 320px;
+        margin-left: auto;
+        margin-right: auto;
         align-items: stretch;
       }
 
@@ -790,6 +792,9 @@
 
       .theme-form--login .theme-form__footer {
         width: 100%;
+        max-width: 320px;
+        margin-left: auto;
+        margin-right: auto;
         align-items: stretch;
       }
 


### PR DESCRIPTION
## Summary
- widen the admin container to provide more horizontal space in the main area
- limit the login form field and footer width so the inputs appear shorter and centered

## Testing
- Manual screenshot of /admin/login

------
https://chatgpt.com/codex/tasks/task_b_68e0aa7b58a4832f914a81f7828a29de