### PR TITLE
Add multi-user management with scoped short links and subdomains

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -1,35 +1,19 @@
 """Shared dependencies for FastAPI routes."""
 from __future__ import annotations
 
-import os
-import secrets
-from typing import Generator
+from typing import Generator, Literal
 from urllib.parse import quote
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from .models import SessionLocal
-from .session import get_session
-
-ADMIN_USER = os.getenv("ADMIN_USER", "admin")
-ADMIN_PASS = os.getenv("ADMIN_PASS", "admin")
+from .models import SessionLocal, User
+from .security import needs_rehash, rehash_password, verify_password
+from .session import get_session, set_session
 
 security = HTTPBasic(auto_error=False)
-
-
-def _authenticate(username: str, password: str) -> tuple[bool, str | None]:
-    """Validate credential pairs and return status plus failure reason."""
-
-    safe_username = username or ""
-    safe_password = password or ""
-
-    if not secrets.compare_digest(safe_username, ADMIN_USER or ""):
-        return False, "username"
-    if not secrets.compare_digest(safe_password, ADMIN_PASS or ""):
-        return False, "password"
-    return True, None
 
 
 def get_db() -> Generator[Session, None, None]:
@@ -42,45 +26,66 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
-def require_basic_auth(credentials: HTTPBasicCredentials | None = Depends(security)) -> None:
-    """Enforce HTTP Basic authentication using environment credentials."""
+def _authenticate(
+    db: Session, username: str, password: str
+) -> tuple[bool, Literal["username", "password", None], User | None]:
+    """Validate credential pairs and return status plus failure reason."""
 
-    if credentials is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="认证失败",
-            headers={"WWW-Authenticate": "Basic"},
-        )
+    normalized_username = (username or "").strip().lower()
+    if not normalized_username:
+        return False, "username", None
 
-    ok, _ = _authenticate(credentials.username, credentials.password)
-    if not ok:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="认证失败",
-            headers={"WWW-Authenticate": "Basic"},
-        )
+    user = db.scalar(select(User).where(User.username == normalized_username))
+    if user is None:
+        return False, "username", None
+
+    if not verify_password(password or "", user.password_hash):
+        return False, "password", None
+
+    if needs_rehash(user.password_hash):
+        user.password_hash = rehash_password(password or "", user.password_hash)
+        db.add(user)
+        db.commit()
+
+    return True, None, user
 
 
-def require_admin_auth(
-    request: Request,
-    credentials: HTTPBasicCredentials | None = Depends(security),
-) -> None:
-    """Allow either session-based login or HTTP Basic credentials."""
-
+def _session_user(request: Request, db: Session) -> User | None:
     session = get_session(request)
-    if session.get("is_authenticated"):
-        return
+    user_id = session.get("user_id")
+    if not user_id:
+        return None
+    user = db.get(User, user_id)
+    if user is None:
+        return None
+    return user
+
+
+def require_authenticated_user(
+    request: Request,
+    db: Session = Depends(get_db),
+    credentials: HTTPBasicCredentials | None = Depends(security),
+) -> User:
+    """Resolve the current authenticated user or raise if unauthenticated."""
+
+    user = _session_user(request, db)
+    if user is not None:
+        return user
 
     accept_header = (request.headers.get("accept") or "").lower()
-    accepts_html = "text/html" in accept_header
+    expects_html = "text/html" in accept_header
 
-    if credentials is not None and (
-        not request.url.path.startswith("/admin") or not accepts_html
-    ):
-        require_basic_auth(credentials)
-        return
+    if credentials is not None and (not request.url.path.startswith("/admin") or not expects_html):
+        ok, _, basic_user = _authenticate(db, credentials.username, credentials.password)
+        if ok and basic_user is not None:
+            return basic_user
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail="认证失败",
+            headers={"WWW-Authenticate": "Basic"},
+        )
 
-    if accepts_html or request.url.path.startswith("/admin"):
+    if expects_html or request.url.path.startswith("/admin"):
         target = request.url.path
         if request.url.query:
             target = f"{target}?{request.url.query}"
@@ -100,7 +105,32 @@ def require_admin_auth(
     )
 
 
-def validate_credentials(username: str, password: str) -> tuple[bool, str | None]:
+def require_admin_user(current_user: User = Depends(require_authenticated_user)) -> User:
+    """Ensure the current user has administrator privileges."""
+
+    if not current_user.is_admin:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, detail="需要管理员权限")
+    return current_user
+
+
+def validate_credentials(
+    username: str, password: str, db: Session
+) -> tuple[bool, Literal["username", "password", None], User | None]:
     """Expose credential validation for the login flow."""
 
-    return _authenticate(username, password)
+    return _authenticate(db, username, password)
+
+
+def establish_session(response, request: Request, user: User) -> None:
+    """Persist user identity into the signed session cookie."""
+
+    set_session(
+        response,
+        request,
+        {
+            "is_authenticated": True,
+            "user_id": user.id,
+            "username": user.username,
+            "is_admin": user.is_admin,
+        },
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -5,9 +5,19 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from sqlalchemy import DateTime, Integer, String, create_engine, func, inspect, text
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    create_engine,
+    func,
+    inspect,
+    text,
+)
 from sqlalchemy.engine import make_url
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
 
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:////data/data.db")
@@ -54,6 +64,26 @@ engine = create_engine(
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
 
+class User(Base):
+    """系统用户表，支持管理员与普通用户。"""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    password_hash: Mapped[str] = mapped_column(String(512), nullable=False)
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    short_links: Mapped[list["ShortLink"]] = relationship(back_populates="owner")
+    subdomain_redirects: Mapped[list["SubdomainRedirect"]] = relationship(
+        back_populates="owner"
+    )
+
+
 class SubdomainRedirect(Base):
     """子域名重定向规则。"""
 
@@ -67,6 +97,15 @@ class SubdomainRedirect(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     hits: Mapped[int] = mapped_column("hits_int", Integer, default=0, nullable=False)
+    user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
+    owner: Mapped[User | None] = relationship(back_populates="subdomain_redirects")
+
+    @property
+    def owner_username(self) -> str | None:  # pragma: no cover - 简单访问器
+        return self.owner.username if self.owner else None
 
 
 class ShortLink(Base):
@@ -81,6 +120,15 @@ class ShortLink(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
+    owner: Mapped[User | None] = relationship(back_populates="short_links")
+
+    @property
+    def owner_username(self) -> str | None:  # pragma: no cover - 简单访问器
+        return self.owner.username if self.owner else None
 
 
 def ensure_subdomain_hits_column() -> None:
@@ -95,4 +143,30 @@ def ensure_subdomain_hits_column() -> None:
         connection.execute(
             text("ALTER TABLE subdomain_redirects ADD COLUMN hits_int INTEGER NOT NULL DEFAULT 0")
         )
+
+
+def ensure_user_association_columns() -> None:
+    """Ensure legacy tables have user_id columns for ownership tracking."""
+
+    inspector = inspect(engine)
+
+    short_link_columns = {
+        column["name"] for column in inspector.get_columns("short_links")
+    }
+    if "user_id" not in short_link_columns:
+        with engine.begin() as connection:
+            connection.execute(
+                text("ALTER TABLE short_links ADD COLUMN user_id INTEGER REFERENCES users(id)")
+            )
+
+    subdomain_columns = {
+        column["name"] for column in inspector.get_columns("subdomain_redirects")
+    }
+    if "user_id" not in subdomain_columns:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "ALTER TABLE subdomain_redirects ADD COLUMN user_id INTEGER REFERENCES users(id)"
+                )
+            )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 
 class SubdomainRedirectBase(BaseModel):
@@ -28,6 +28,8 @@ class SubdomainRedirect(SubdomainRedirectBase):
     id: int = Field(..., description="数据库主键")
     created_at: datetime = Field(..., description="创建时间")
     hits: int = Field(default=0, description="累计访问次数")
+    user_id: int | None = Field(default=None, description="所属用户 ID")
+    owner_username: str | None = Field(default=None, description="所属用户名")
 
     model_config = {"from_attributes": True}
 
@@ -61,6 +63,8 @@ class ShortLink(ShortLinkBase):
     code: str = Field(..., description="短链编码")
     hits: int = Field(default=0, description="访问次数")
     created_at: datetime = Field(..., description="创建时间")
+    user_id: int | None = Field(default=None, description="所属用户 ID")
+    owner_username: str | None = Field(default=None, description="所属用户名")
 
     model_config = {"from_attributes": True}
 
@@ -75,4 +79,82 @@ class ShortLinkUpdate(ShortLinkBase):
         if not stripped:
             raise ValueError("短链编码不能为空")
         return stripped
+
+
+class UserBase(BaseModel):
+    username: str = Field(..., description="用户名")
+    email: str = Field(..., description="邮箱地址")
+
+    @field_validator("username")
+    @classmethod
+    def _normalize_username(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("用户名不能为空")
+        return normalized
+
+    @field_validator("email")
+    @classmethod
+    def _normalize_email(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("邮箱不能为空")
+        return normalized
+
+
+class UserCreate(UserBase):
+    password: str = Field(..., description="登录密码")
+    is_admin: bool = Field(default=False, description="是否管理员")
+
+    @field_validator("password")
+    @classmethod
+    def _validate_password(cls, value: str) -> str:
+        if len(value) < 6:
+            raise ValueError("密码长度至少为 6 位")
+        return value
+
+
+class UserUpdate(UserBase):
+    is_admin: bool = Field(default=False, description="是否管理员")
+    password: str | None = Field(default=None, description="新密码，可选")
+
+    @field_validator("password")
+    @classmethod
+    def _normalize_password(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if len(value) < 6:
+            raise ValueError("密码长度至少为 6 位")
+        return value
+
+
+class User(BaseModel):
+    id: int
+    username: str
+    email: str
+    is_admin: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PasswordChange(BaseModel):
+    current_password: str = Field(..., description="原密码")
+    new_password: str = Field(..., description="新密码")
+    confirm_password: str = Field(..., description="确认新密码")
+
+    @field_validator("new_password")
+    @classmethod
+    def _validate_new_password(cls, value: str) -> str:
+        if len(value) < 6:
+            raise ValueError("密码长度至少为 6 位")
+        return value
+
+    @field_validator("confirm_password")
+    @classmethod
+    def _validate_confirm(cls, value: str, info: ValidationInfo) -> str:
+        new_password = info.data.get("new_password") if info.data else None
+        if new_password is not None and value != new_password:
+            raise ValueError("两次输入的密码不一致")
+        return value
 

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,74 @@
+"""密码哈希与校验工具。"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from typing import Final
+
+_HASH_ALGORITHM: Final = "sha256"
+_DEFAULT_ITERATIONS: Final = 600_000
+
+
+class PasswordFormatError(ValueError):
+    """Raised when a stored password hash cannot be parsed."""
+
+
+def _split_components(stored: str) -> tuple[str, int, bytes, bytes]:
+    try:
+        scheme, iterations_str, salt_hex, hash_hex = stored.split("$", 3)
+        iterations = int(iterations_str)
+        salt = bytes.fromhex(salt_hex)
+        hashed = bytes.fromhex(hash_hex)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise PasswordFormatError("invalid password hash format") from exc
+    if scheme != "pbkdf2_sha256":  # pragma: no cover - defensive
+        raise PasswordFormatError(f"unsupported hash scheme: {scheme}")
+    return scheme, iterations, salt, hashed
+
+
+def hash_password(password: str, *, salt: bytes | None = None, iterations: int = _DEFAULT_ITERATIONS) -> str:
+    """Hash a password using PBKDF2-HMAC-SHA256."""
+
+    if not isinstance(password, str) or not password:
+        raise ValueError("password must be a non-empty string")
+    salt_bytes = salt or secrets.token_bytes(16)
+    derived = hashlib.pbkdf2_hmac(
+        _HASH_ALGORITHM, password.encode("utf-8"), salt_bytes, iterations
+    )
+    return "pbkdf2_sha256$%d$%s$%s" % (
+        iterations,
+        salt_bytes.hex(),
+        derived.hex(),
+    )
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """Verify a plaintext password against the stored hash."""
+
+    try:
+        _, iterations, salt, expected = _split_components(stored_hash)
+    except PasswordFormatError:
+        return False
+    candidate = hashlib.pbkdf2_hmac(
+        _HASH_ALGORITHM, password.encode("utf-8"), salt, iterations
+    )
+    return hmac.compare_digest(candidate, expected)
+
+
+def needs_rehash(stored_hash: str, *, iterations: int = _DEFAULT_ITERATIONS) -> bool:
+    """Determine whether the stored hash should be upgraded."""
+
+    try:
+        _, stored_iterations, _, _ = _split_components(stored_hash)
+    except PasswordFormatError:
+        return True
+    return stored_iterations < iterations
+
+
+def rehash_password(password: str, stored_hash: str) -> str:
+    """Rehash a password with the recommended iterations if needed."""
+
+    if not needs_rehash(stored_hash):
+        return stored_hash
+    return hash_password(password)

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -30,6 +30,24 @@
         {% include "admin/partials/subdomain_count.html" %}
         {% endwith %}
       </a>
+      {% if current_user and current_user.is_admin %}
+      <a
+        href="?tab=users"
+        class="theme-tab {% if active_tab == 'users' %}is-active{% endif %}"
+      >
+        <span class="theme-tab__dot"></span>
+        用户
+        <span
+          class="theme-tab__count"
+          id="user-count"
+          hx-get="/admin/users/count"
+          hx-trigger="load, refresh-users from:body"
+          hx-swap="outerHTML"
+        >
+          ({{ users|length }})
+        </span>
+      </a>
+      {% endif %}
     </nav>
     <div class="theme-shell__body">
       {% if active_tab == 'links' %}
@@ -116,7 +134,7 @@
           </div>
         </section>
       </div>
-      {% else %}
+      {% elif active_tab == 'subdomains' %}
       <div class="theme-stack">
         <section class="theme-card">
           <div class="theme-card__header">
@@ -208,6 +226,115 @@
             hx-swap="innerHTML"
           >
             {% include "admin/partials/subdomain_table.html" %}
+          </div>
+        </section>
+      </div>
+      {% else %}
+      <div class="theme-stack">
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">创建用户</h2>
+            <p class="theme-card__subtitle">
+              管理员可在此创建新用户，设置邮箱与初始密码，可选择是否授予管理员权限。
+            </p>
+          </div>
+          <div class="theme-card__body">
+            <form
+              class="theme-form"
+              action="/api/users"
+              method="post"
+              hx-post="/api/users"
+              hx-trigger="submit"
+              hx-target="#user-feedback"
+              hx-swap="innerHTML"
+              data-reset-on-success="true"
+              data-success-event="refresh-users"
+            >
+              <div class="theme-form__grid theme-form__grid--two">
+                <div class="theme-field">
+                  <label for="user-username" class="theme-label">用户名 *</label>
+                  <input
+                    id="user-username"
+                    name="username"
+                    type="text"
+                    required
+                    class="theme-input"
+                    placeholder="如 alice"
+                    autocomplete="off"
+                    spellcheck="false"
+                  />
+                </div>
+                <div class="theme-field">
+                  <label for="user-email" class="theme-label">邮箱 *</label>
+                  <input
+                    id="user-email"
+                    name="email"
+                    type="email"
+                    required
+                    class="theme-input"
+                    placeholder="user@example.com"
+                  />
+                </div>
+                <div class="theme-field">
+                  <label for="user-password" class="theme-label">密码 *</label>
+                  <input
+                    id="user-password"
+                    name="password"
+                    type="password"
+                    minlength="6"
+                    required
+                    class="theme-input"
+                    placeholder="至少 6 位"
+                  />
+                </div>
+                <div class="theme-field">
+                  <label for="user-password-confirm" class="theme-label">确认密码 *</label>
+                  <input
+                    id="user-password-confirm"
+                    name="password_confirm"
+                    type="password"
+                    minlength="6"
+                    required
+                    class="theme-input"
+                    placeholder="再次输入密码"
+                  />
+                </div>
+                <div class="theme-field theme-form__span-full">
+                  <label class="theme-checkbox">
+                    <input type="checkbox" name="is_admin" value="1" />
+                    <span>授予管理员权限</span>
+                  </label>
+                </div>
+              </div>
+              <div class="theme-form__footer theme-form__footer--center">
+                <button type="submit" class="theme-button theme-button--solid">
+                  创建用户
+                </button>
+              </div>
+            </form>
+          </div>
+          <div
+            id="user-feedback"
+            class="theme-feedback"
+            role="status"
+            aria-live="polite"
+          ></div>
+        </section>
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">用户列表</h2>
+            <p class="theme-card__subtitle">
+              查看平台用户及权限，支持编辑资料或删除用户。
+            </p>
+          </div>
+          <div
+            id="users-table"
+            class="theme-card__body theme-card__body--table"
+            hx-get="/admin/users/table"
+            hx-trigger="load, refresh-users from:body"
+            hx-swap="innerHTML"
+          >
+            {% include "admin/partials/user_table.html" %}
           </div>
         </section>
       </div>

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -1,5 +1,5 @@
 <tr id="short-link-row-{{ item.id }}" class="theme-table__row theme-table__row--editing">
-  <td colspan="5" class="theme-table__cell">
+  <td colspan="{{ 5 + (1 if show_user_column else 0) }}" class="theme-table__cell">
     <form
       class="theme-form"
       hx-put="/api/links/{{ item.id }}"

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -25,6 +25,11 @@
   <td class="theme-table__cell theme-table__cell--muted">
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
   </td>
+  {% if show_user_column %}
+  <td class="theme-table__cell theme-table__cell--muted">
+    {{ item.owner_username or '—' }}
+  </td>
+  {% endif %}
   <td class="theme-table__cell theme-table__cell--right">
     <div class="theme-table__actions">
       <button

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -6,6 +6,9 @@
       <th scope="col">目标地址</th>
       <th scope="col">访问次数</th>
       <th scope="col">创建时间</th>
+      {% if show_user_column %}
+      <th scope="col">用户</th>
+      {% endif %}
       <th scope="col" class="theme-table__cell--right">操作</th>
     </tr>
   </thead>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -1,5 +1,5 @@
 <tr id="subdomain-row-{{ item.id }}" class="theme-table__row theme-table__row--editing">
-  <td colspan="6" class="theme-table__cell">
+  <td colspan="{{ 6 + (1 if show_user_column else 0) }}" class="theme-table__cell">
     <form
       class="theme-form"
       hx-put="/api/subdomains/{{ item.id }}"

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -26,6 +26,9 @@
   <td class="theme-table__cell theme-table__cell--muted">
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
   </td>
+  {% if show_user_column %}
+  <td class="theme-table__cell theme-table__cell--muted">{{ item.owner_username or '—' }}</td>
+  {% endif %}
   <td class="theme-table__cell theme-table__cell--right">
     <div class="theme-table__actions">
       <button

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -7,6 +7,9 @@
       <th scope="col">状态码</th>
       <th scope="col">访问次数</th>
       <th scope="col">创建时间</th>
+      {% if show_user_column %}
+      <th scope="col">用户</th>
+      {% endif %}
       <th scope="col" class="theme-table__cell--right">操作</th>
     </tr>
   </thead>

--- a/backend/app/templates/admin/partials/user_count.html
+++ b/backend/app/templates/admin/partials/user_count.html
@@ -1,0 +1,9 @@
+<span
+  class="theme-tab__count"
+  id="user-count"
+  hx-get="/admin/users/count"
+  hx-trigger="load, refresh-users from:body"
+  hx-swap="outerHTML"
+>
+  ({{ count }})
+</span>

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -1,0 +1,83 @@
+<tr id="user-row-{{ item.id }}" class="theme-table__row theme-table__row--editing">
+  <td colspan="5" class="theme-table__cell">
+    <form
+      class="theme-form"
+      hx-put="/api/users/{{ item.id }}"
+      hx-target="#user-feedback"
+      hx-swap="innerHTML"
+      data-success-event="refresh-users"
+    >
+      <div class="theme-form__grid theme-form__grid--two">
+        <div class="theme-field">
+          <label for="edit-username-{{ item.id }}" class="theme-label">用户名</label>
+          <input
+            id="edit-username-{{ item.id }}"
+            name="username"
+            type="text"
+            required
+            value="{{ item.username }}"
+            class="theme-input"
+            autocomplete="off"
+            spellcheck="false"
+          />
+        </div>
+        <div class="theme-field">
+          <label for="edit-email-{{ item.id }}" class="theme-label">邮箱</label>
+          <input
+            id="edit-email-{{ item.id }}"
+            name="email"
+            type="email"
+            required
+            value="{{ item.email }}"
+            class="theme-input"
+          />
+        </div>
+        <div class="theme-field">
+          <label for="edit-password-{{ item.id }}" class="theme-label">新密码</label>
+          <input
+            id="edit-password-{{ item.id }}"
+            name="password"
+            type="password"
+            minlength="6"
+            class="theme-input"
+            placeholder="留空则不修改"
+          />
+        </div>
+        <div class="theme-field">
+          <label for="edit-password-confirm-{{ item.id }}" class="theme-label">确认密码</label>
+          <input
+            id="edit-password-confirm-{{ item.id }}"
+            name="password_confirm"
+            type="password"
+            minlength="6"
+            class="theme-input"
+            placeholder="再次输入新密码"
+          />
+        </div>
+        <div class="theme-field theme-form__span-full">
+          <label class="theme-checkbox">
+            <input type="checkbox" name="is_admin" value="1" {% if item.is_admin %}checked{% endif %} />
+            <span>管理员权限</span>
+          </label>
+        </div>
+      </div>
+      <div class="theme-form__footer">
+        <p class="theme-helper">保存后用户信息会立即更新。</p>
+        <div class="theme-form__actions">
+          <button
+            type="button"
+            class="theme-button theme-button--ghost theme-button--sm"
+            hx-get="/admin/users/{{ item.id }}/row"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+          >
+            取消
+          </button>
+          <button type="submit" class="theme-button theme-button--solid theme-button--sm">
+            保存
+          </button>
+        </div>
+      </div>
+    </form>
+  </td>
+</tr>

--- a/backend/app/templates/admin/partials/user_row.html
+++ b/backend/app/templates/admin/partials/user_row.html
@@ -1,0 +1,44 @@
+<tr
+  id="user-row-{{ item.id }}"
+  class="theme-table__row"
+  {% if oob %}hx-swap-oob="outerHTML"{% endif %}
+>
+  <td class="theme-table__cell theme-table__cell--wrap">
+    {{ item.username }}
+  </td>
+  <td class="theme-table__cell theme-table__cell--muted">{{ item.email }}</td>
+  <td class="theme-table__cell">
+    {% if item.is_admin %}
+    <span class="theme-pill">管理员</span>
+    {% else %}
+    普通用户
+    {% endif %}
+  </td>
+  <td class="theme-table__cell theme-table__cell--muted">
+    {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+  </td>
+  <td class="theme-table__cell theme-table__cell--right">
+    <div class="theme-table__actions">
+      <button
+        type="button"
+        class="theme-button theme-button--ghost theme-button--sm"
+        hx-get="/admin/users/{{ item.id }}/edit"
+        hx-target="closest tr"
+        hx-swap="outerHTML"
+      >
+        编辑
+      </button>
+      <button
+        type="button"
+        class="theme-button theme-button--danger theme-button--sm"
+        hx-delete="/api/users/{{ item.id }}"
+        hx-target="#user-feedback"
+        hx-swap="innerHTML"
+        hx-confirm="确认删除该用户？"
+        data-success-event="refresh-users"
+      >
+        删除
+      </button>
+    </div>
+  </td>
+</tr>

--- a/backend/app/templates/admin/partials/user_table.html
+++ b/backend/app/templates/admin/partials/user_table.html
@@ -1,0 +1,20 @@
+{% if users %}
+<table class="theme-table">
+  <thead>
+    <tr>
+      <th scope="col">用户名</th>
+      <th scope="col">邮箱</th>
+      <th scope="col">权限</th>
+      <th scope="col">创建时间</th>
+      <th scope="col" class="theme-table__cell--right">操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in users %}
+    {% include "admin/partials/user_row.html" %}
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="theme-table__empty">暂无用户记录。</div>
+{% endif %}

--- a/backend/app/templates/admin/password.html
+++ b/backend/app/templates/admin/password.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="theme-layout">
+  <section class="theme-shell">
+    <div class="theme-shell__body">
+      <div class="theme-stack">
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">修改密码</h2>
+            <p class="theme-card__subtitle">
+              为保障账户安全，请填写当前密码并设置至少 6 位的新密码。
+            </p>
+          </div>
+          <div class="theme-card__body">
+            <form
+              class="theme-form"
+              action="/api/users/me/password"
+              method="post"
+              hx-post="/api/users/me/password"
+              hx-trigger="submit"
+              hx-target="#password-feedback"
+              hx-swap="innerHTML"
+              data-reset-on-success="true"
+            >
+              <div class="theme-form__grid theme-form__grid--two">
+                <div class="theme-field">
+                  <label for="current_password" class="theme-label">当前密码 *</label>
+                  <input
+                    id="current_password"
+                    name="current_password"
+                    type="password"
+                    required
+                    class="theme-input"
+                    autocomplete="current-password"
+                  />
+                </div>
+                <div class="theme-field">
+                  <label for="new_password" class="theme-label">新密码 *</label>
+                  <input
+                    id="new_password"
+                    name="new_password"
+                    type="password"
+                    minlength="6"
+                    required
+                    class="theme-input"
+                    autocomplete="new-password"
+                  />
+                </div>
+                <div class="theme-field theme-form__span-full">
+                  <label for="confirm_password" class="theme-label">确认新密码 *</label>
+                  <input
+                    id="confirm_password"
+                    name="confirm_password"
+                    type="password"
+                    minlength="6"
+                    required
+                    class="theme-input"
+                    autocomplete="new-password"
+                  />
+                </div>
+              </div>
+              <div class="theme-form__footer theme-form__footer--center">
+                <button type="submit" class="theme-button theme-button--solid">
+                  更新密码
+                </button>
+                <a href="/admin" class="theme-button theme-button--ghost">返回仪表盘</a>
+              </div>
+            </form>
+          </div>
+          <div
+            id="password-feedback"
+            class="theme-feedback"
+            role="status"
+            aria-live="polite"
+          ></div>
+        </section>
+      </div>
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1315,6 +1315,12 @@
             </div>
             {% if show_logout_button %}
             <a
+              class="theme-button theme-button--ghost theme-button--password"
+              href="/admin/password"
+            >
+              修改密码
+            </a>
+            <a
               class="theme-button theme-button--ghost theme-button--logout"
               href="/admin/logout"
               onclick="return confirm('确认退出登录？')"

--- a/backend/app/user_service.py
+++ b/backend/app/user_service.py
@@ -1,0 +1,54 @@
+"""User management helpers for startup and CRUD operations."""
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import select
+
+from .models import SessionLocal, User
+from .security import hash_password, needs_rehash, verify_password
+
+DEFAULT_ADMIN_USER = os.getenv("ADMIN_USER", "admin").strip().lower()
+DEFAULT_ADMIN_PASSWORD = os.getenv("ADMIN_PASS", "admin")
+DEFAULT_ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "admin@example.com")
+
+
+def ensure_default_admin() -> None:
+    """Ensure the default admin user exists in the database."""
+
+    if not DEFAULT_ADMIN_USER or not DEFAULT_ADMIN_PASSWORD:
+        return
+
+    with SessionLocal() as session:
+        existing = session.scalar(
+            select(User).where(User.username == DEFAULT_ADMIN_USER)
+        )
+        if existing is None:
+            admin = User(
+                username=DEFAULT_ADMIN_USER,
+                email=DEFAULT_ADMIN_EMAIL,
+                password_hash=hash_password(DEFAULT_ADMIN_PASSWORD),
+                is_admin=True,
+            )
+            session.add(admin)
+            session.commit()
+            return
+
+        updated = False
+        if not existing.is_admin:
+            existing.is_admin = True
+            updated = True
+        if existing.email != DEFAULT_ADMIN_EMAIL:
+            existing.email = DEFAULT_ADMIN_EMAIL
+            updated = True
+
+        if not verify_password(DEFAULT_ADMIN_PASSWORD, existing.password_hash):
+            existing.password_hash = hash_password(DEFAULT_ADMIN_PASSWORD)
+            updated = True
+        elif needs_rehash(existing.password_hash):
+            existing.password_hash = hash_password(DEFAULT_ADMIN_PASSWORD)
+            updated = True
+
+        if updated:
+            session.add(existing)
+            session.commit()

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,97 @@
+ADMIN_AUTH = ("admin", "admin")
+
+
+def test_admin_can_create_update_delete_user(client: "SimpleClient") -> None:
+    created = client.post(
+        "/api/users",
+        json={
+            "username": "tester",
+            "email": "tester@example.com",
+            "password": "testpass",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+    assert created.status_code == 201
+    payload = created.json()
+    assert payload["username"] == "tester"
+    assert payload["email"] == "tester@example.com"
+    assert payload["is_admin"] is False
+
+    updated = client.put(
+        f"/api/users/{payload['id']}",
+        data={
+            "username": "tester",
+            "email": "new@example.com",
+            "password": "newpass",
+            "password_confirm": "newpass",
+            "is_admin": "1",
+        },
+        headers={"hx-request": "true"},
+        auth=ADMIN_AUTH,
+    )
+    assert updated.status_code == 200
+    assert "用户信息已更新" in updated.text
+    assert updated.headers.get("hx-trigger") == "refresh-users"
+
+    deleted = client.delete(
+        f"/api/users/{payload['id']}",
+        headers={"hx-request": "true"},
+        auth=ADMIN_AUTH,
+    )
+    assert deleted.status_code == 200
+    assert "用户已删除" in deleted.text
+    assert deleted.headers.get("hx-trigger") == "refresh-users"
+
+
+def test_non_admin_cannot_access_user_management(client: "SimpleClient") -> None:
+    client.post(
+        "/api/users",
+        json={
+            "username": "limited",
+            "email": "limited@example.com",
+            "password": "limitedpass",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+
+    user_auth = ("limited", "limitedpass")
+
+    listing = client.get("/api/users", auth=user_auth)
+    assert listing.status_code == 403
+    assert listing.json()["detail"] == "需要管理员权限"
+
+    creation = client.post(
+        "/api/users",
+        json={
+            "username": "other",
+            "email": "other@example.com",
+            "password": "otherpass",
+            "is_admin": False,
+        },
+        auth=user_auth,
+    )
+    assert creation.status_code == 403
+    assert creation.json()["detail"] == "需要管理员权限"
+
+
+def test_admin_user_partials(client: "SimpleClient") -> None:
+    client.post(
+        "/api/users",
+        json={
+            "username": "viewer",
+            "email": "viewer@example.com",
+            "password": "viewerpass",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+
+    table = client.get("/admin/users/table", auth=ADMIN_AUTH)
+    assert table.status_code == 200
+    assert "viewer@example.com" in table.text
+
+    count = client.get("/admin/users/count", auth=ADMIN_AUTH)
+    assert count.status_code == 200
+    assert "user-count" in count.text


### PR DESCRIPTION
## Summary
- add database-backed user accounts with hashed passwords and ensure a default admin user
- scope short link and subdomain APIs/UI to the authenticated user while surfacing owner details for admins
- introduce admin user management screens and password change flow with corresponding tests

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_b_68e0b2843148832fab95ef9810c529b0