### PR TITLE
Fix user management layout and fallback refresh

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -218,6 +218,38 @@
     dispatchSuccessEvent(formLike);
   }
 
+  async function refreshUsers() {
+    const countAnchor = document.getElementById("user-count");
+    if (countAnchor) {
+      try {
+        const { response, text } = await fetchFragment("/admin/users/count", {
+          method: "GET",
+          headers: buildHeaders(),
+        });
+        if (response.ok) {
+          swapContent(countAnchor, text, "outerHTML");
+        }
+      } catch (error) {
+        console.error("Failed to refresh user count", error);
+      }
+    }
+
+    const tableContainer = document.getElementById("users-table");
+    if (tableContainer) {
+      try {
+        const { response, text } = await fetchFragment("/admin/users/table", {
+          method: "GET",
+          headers: buildHeaders(),
+        });
+        if (response.ok) {
+          swapContent(tableContainer, text, "innerHTML");
+        }
+      } catch (error) {
+        console.error("Failed to refresh user table", error);
+      }
+    }
+  }
+
   async function refreshLinks() {
     const countAnchor = document.getElementById("short-link-count");
     if (countAnchor) {
@@ -704,12 +736,15 @@
       "htmx 未加载，使用回退逻辑处理短链子域管理后台交互。\n建议检查 CDN 是否可访问。"
     );
 
+    const refreshUsersHandler = () => refreshUsers();
     const refreshLinksHandler = () => refreshLinks();
     const refreshSubdomainsHandler = () => refreshSubdomains();
 
+    document.body.addEventListener("refresh-users", refreshUsersHandler);
     document.body.addEventListener("refresh-links", refreshLinksHandler);
     document.body.addEventListener("refresh-subdomains", refreshSubdomainsHandler);
 
+    refreshUsersHandler();
     refreshLinksHandler();
     refreshSubdomainsHandler();
 

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -71,7 +71,7 @@
               data-reset-on-success="true"
               data-success-event="refresh-links"
             >
-              <div class="theme-form__grid theme-form__grid--two">
+              <div class="theme-form__grid theme-form__grid--two-fixed">
                 <div class="theme-field">
                   <label for="code" class="theme-label">短链（可改）</label>
                   <div class="theme-input-affix">
@@ -250,7 +250,7 @@
               data-reset-on-success="true"
               data-success-event="refresh-users"
             >
-              <div class="theme-form__grid theme-form__grid--two">
+              <div class="theme-form__grid theme-form__grid--two-fixed">
                 <div class="theme-field">
                   <label for="user-username" class="theme-label">用户名 *</label>
                   <input

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -7,7 +7,7 @@
       hx-swap="innerHTML"
       data-success-event="refresh-users"
     >
-      <div class="theme-form__grid theme-form__grid--two">
+      <div class="theme-form__grid theme-form__grid--two-fixed">
         <div class="theme-field">
           <label for="edit-username-{{ item.id }}" class="theme-label">用户名</label>
           <input

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -813,6 +813,16 @@
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       }
 
+      .theme-form__grid--two-fixed {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      @media (max-width: 640px) {
+        .theme-form__grid--two-fixed {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+
       .theme-form__grid--three {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       }


### PR DESCRIPTION
## Summary
- ensure user creation and edit forms use a fixed two-column layout for account and password fields
- add a JavaScript fallback refresh handler so user counts and tables reload after create, edit, and delete actions
- extend the shared styles to support the new fixed two-column grid used by the user forms

## Testing
- pytest backend/tests/test_users.py

------
https://chatgpt.com/codex/tasks/task_b_68e113abf1d8832f929ccd179a7c4755