### PR TITLE
Fix admin editing controls and adjust password layout

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -301,6 +301,7 @@
                 </div>
                 <div class="theme-field theme-form__span-full">
                   <label class="theme-checkbox">
+                    <input type="hidden" name="is_admin" value="0" />
                     <input type="checkbox" name="is_admin" value="1" />
                     <span>授予管理员权限</span>
                   </label>

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -56,6 +56,7 @@
         </div>
         <div class="theme-field theme-form__span-full">
           <label class="theme-checkbox">
+            <input type="hidden" name="is_admin" value="0" />
             <input type="checkbox" name="is_admin" value="1" {% if item.is_admin %}checked{% endif %} />
             <span>管理员权限</span>
           </label>

--- a/backend/app/templates/admin/password.html
+++ b/backend/app/templates/admin/password.html
@@ -3,16 +3,15 @@
 {% block content %}
 <div class="theme-layout">
   <section class="theme-shell">
-    <div class="theme-shell__body">
-      <div class="theme-stack">
-        <section class="theme-card">
-          <div class="theme-card__header">
+    <div class="theme-shell__body theme-shell__body--center">
+      <section class="theme-card theme-card--narrow">
+        <div class="theme-card__header theme-card__header--center">
             <h2 class="theme-card__title">修改密码</h2>
             <p class="theme-card__subtitle">
               为保障账户安全，请填写当前密码并设置至少 6 位的新密码。
             </p>
-          </div>
-          <div class="theme-card__body">
+        </div>
+        <div class="theme-card__body">
             <form
               class="theme-form"
               action="/api/users/me/password"
@@ -67,15 +66,14 @@
                 <a href="/admin" class="theme-button theme-button--ghost">返回仪表盘</a>
               </div>
             </form>
-          </div>
-          <div
-            id="password-feedback"
-            class="theme-feedback"
-            role="status"
-            aria-live="polite"
-          ></div>
-        </section>
-      </div>
+        </div>
+        <div
+          id="password-feedback"
+          class="theme-feedback"
+          role="status"
+          aria-live="polite"
+        ></div>
+      </section>
     </div>
   </section>
 </div>


### PR DESCRIPTION
## Summary
- ensure admin permission checkboxes submit an explicit false value for user creation and edits
- align the password change card width with the login form layout
- close any other open edit rows before opening a new editor for links, subdomains, or users

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e1250e5eb8832fa3f57e05f3cbdb9f