### PR TITLE
Improve admin permission checkbox usability

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -300,11 +300,19 @@
                   />
                 </div>
                 <div class="theme-field theme-form__span-full">
-                  <label class="theme-checkbox">
+                  <div class="theme-checkbox">
                     <input type="hidden" name="is_admin" value="0" />
-                    <input type="checkbox" name="is_admin" value="1" />
-                    <span>授予管理员权限</span>
-                  </label>
+                    <input
+                      id="create-is-admin"
+                      class="theme-checkbox__control"
+                      type="checkbox"
+                      name="is_admin"
+                      value="1"
+                    />
+                    <label for="create-is-admin" class="theme-checkbox__label">
+                      授予管理员权限
+                    </label>
+                  </div>
                 </div>
               </div>
               <div class="theme-form__footer theme-form__footer--center">

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -55,11 +55,23 @@
           />
         </div>
         <div class="theme-field theme-form__span-full">
-          <label class="theme-checkbox">
+          <div class="theme-checkbox">
             <input type="hidden" name="is_admin" value="0" />
-            <input type="checkbox" name="is_admin" value="1" {% if item.is_admin %}checked{% endif %} />
-            <span>管理员权限</span>
-          </label>
+            <input
+              id="edit-is-admin-{{ item.id }}"
+              class="theme-checkbox__control"
+              type="checkbox"
+              name="is_admin"
+              value="1"
+              {% if item.is_admin %}checked{% endif %}
+            />
+            <label
+              for="edit-is-admin-{{ item.id }}"
+              class="theme-checkbox__label"
+            >
+              管理员权限
+            </label>
+          </div>
         </div>
       </div>
       <div class="theme-form__footer">

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -844,6 +844,63 @@
         justify-self: start;
       }
 
+      .theme-checkbox {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        font-weight: 600;
+        color: var(--theme-text-secondary);
+      }
+
+      .theme-checkbox__control {
+        appearance: none;
+        width: 1.125rem;
+        height: 1.125rem;
+        border-radius: 0.35rem;
+        border: 2px solid var(--theme-input-border);
+        background: var(--theme-input-bg);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: border-color 0.2s ease, background 0.2s ease,
+          box-shadow 0.2s ease;
+      }
+
+      .theme-checkbox__control::after {
+        content: "";
+        width: 0.55rem;
+        height: 0.55rem;
+        border-radius: 0.2rem;
+        background: var(--theme-button-solid-bg);
+        transform: scale(0);
+        transition: transform 0.18s ease;
+      }
+
+      .theme-checkbox__control:focus-visible {
+        outline: none;
+        border-color: var(--theme-input-focus-border);
+        box-shadow: var(--theme-input-focus-shadow);
+      }
+
+      .theme-checkbox__control:checked {
+        border-color: var(--theme-button-solid-bg);
+        background: rgba(99, 102, 241, 0.16);
+      }
+
+      :root[data-theme="nebula"] .theme-checkbox__control:checked {
+        border-color: var(--theme-primary);
+        background: rgba(56, 189, 248, 0.18);
+      }
+
+      .theme-checkbox__control:checked::after {
+        transform: scale(1);
+      }
+
+      .theme-checkbox__label {
+        cursor: pointer;
+      }
+
       .theme-label {
         font-size: 0.9rem;
         font-weight: 600;


### PR DESCRIPTION
## Summary
- update the user creation and edit forms to use explicit checkbox controls for the admin permission toggle
- add reusable styles for the custom checkbox so it remains interactive across themes

## Testing
- pytest backend/tests/test_users.py::test_admin_can_create_update_delete_user -q

------
https://chatgpt.com/codex/tasks/task_b_68e12a10d7c0832fac04ef954cf47125