### PR TITLE
Improve admin user role editing and default password behavior

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -300,19 +300,15 @@
                   />
                 </div>
                 <div class="theme-field theme-form__span-full">
-                  <div class="theme-checkbox">
-                    <input type="hidden" name="is_admin" value="0" />
-                    <input
-                      id="create-is-admin"
-                      class="theme-checkbox__control"
-                      type="checkbox"
-                      name="is_admin"
-                      value="1"
-                    />
-                    <label for="create-is-admin" class="theme-checkbox__label">
-                      授予管理员权限
-                    </label>
-                  </div>
+                  <label for="create-role" class="theme-label">权限</label>
+                  <select
+                    id="create-role"
+                    name="is_admin"
+                    class="theme-input"
+                  >
+                    <option value="0" selected>普通用户</option>
+                    <option value="1">管理员</option>
+                  </select>
                 </div>
               </div>
               <div class="theme-form__footer theme-form__footer--center">

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -55,23 +55,15 @@
           />
         </div>
         <div class="theme-field theme-form__span-full">
-          <div class="theme-checkbox">
-            <input type="hidden" name="is_admin" value="0" />
-            <input
-              id="edit-is-admin-{{ item.id }}"
-              class="theme-checkbox__control"
-              type="checkbox"
-              name="is_admin"
-              value="1"
-              {% if item.is_admin %}checked{% endif %}
-            />
-            <label
-              for="edit-is-admin-{{ item.id }}"
-              class="theme-checkbox__label"
-            >
-              管理员权限
-            </label>
-          </div>
+          <label for="edit-role-{{ item.id }}" class="theme-label">权限</label>
+          <select
+            id="edit-role-{{ item.id }}"
+            name="is_admin"
+            class="theme-input"
+          >
+            <option value="0" {% if not item.is_admin %}selected{% endif %}>普通用户</option>
+            <option value="1" {% if item.is_admin %}selected{% endif %}>管理员</option>
+          </select>
         </div>
       </div>
       <div class="theme-form__footer">

--- a/backend/app/user_service.py
+++ b/backend/app/user_service.py
@@ -38,14 +38,14 @@ def ensure_default_admin() -> None:
         if not existing.is_admin:
             existing.is_admin = True
             updated = True
-        if existing.email != DEFAULT_ADMIN_EMAIL:
+        if not existing.email:
             existing.email = DEFAULT_ADMIN_EMAIL
             updated = True
 
-        if not verify_password(DEFAULT_ADMIN_PASSWORD, existing.password_hash):
-            existing.password_hash = hash_password(DEFAULT_ADMIN_PASSWORD)
-            updated = True
-        elif needs_rehash(existing.password_hash):
+        password_matches_default = verify_password(
+            DEFAULT_ADMIN_PASSWORD, existing.password_hash
+        )
+        if password_matches_default and needs_rehash(existing.password_hash):
             existing.password_hash = hash_password(DEFAULT_ADMIN_PASSWORD)
             updated = True
 


### PR DESCRIPTION
## Summary
- replace the admin permission checkboxes on the user create and edit forms with dropdowns so the role can always be changed
- stop forcing the default admin password from the .env file after the account exists while still rehashing it when required

## Testing
- pytest backend/tests/test_users.py

------
https://chatgpt.com/codex/tasks/task_b_68e12e37e238832f8bc4533ca43d70ff