### PR TITLE
Adjust admin user forms layout

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -251,29 +251,42 @@
               data-success-event="refresh-users"
             >
               <div class="theme-form__grid theme-form__grid--two-fixed">
-                <div class="theme-field">
-                  <label for="user-username" class="theme-label">用户名 *</label>
-                  <input
-                    id="user-username"
-                    name="username"
-                    type="text"
-                    required
-                    class="theme-input"
-                    placeholder="如 alice"
-                    autocomplete="off"
-                    spellcheck="false"
-                  />
-                </div>
-                <div class="theme-field">
-                  <label for="user-email" class="theme-label">邮箱 *</label>
-                  <input
-                    id="user-email"
-                    name="email"
-                    type="email"
-                    required
-                    class="theme-input"
-                    placeholder="user@example.com"
-                  />
+                <div class="theme-form__grid theme-form__grid--user-identity theme-form__span-full">
+                  <div class="theme-field">
+                    <label for="user-username" class="theme-label">用户名 *</label>
+                    <input
+                      id="user-username"
+                      name="username"
+                      type="text"
+                      required
+                      class="theme-input"
+                      placeholder="如 alice"
+                      autocomplete="off"
+                      spellcheck="false"
+                    />
+                  </div>
+                  <div class="theme-field">
+                    <label for="user-email" class="theme-label">邮箱 *</label>
+                    <input
+                      id="user-email"
+                      name="email"
+                      type="email"
+                      required
+                      class="theme-input"
+                      placeholder="user@example.com"
+                    />
+                  </div>
+                  <div class="theme-field">
+                    <label for="create-role" class="theme-label">权限</label>
+                    <select
+                      id="create-role"
+                      name="is_admin"
+                      class="theme-input theme-input--compact"
+                    >
+                      <option value="0" selected>普通用户</option>
+                      <option value="1">管理员</option>
+                    </select>
+                  </div>
                 </div>
                 <div class="theme-field">
                   <label for="user-password" class="theme-label">密码 *</label>
@@ -298,17 +311,6 @@
                     class="theme-input"
                     placeholder="再次输入密码"
                   />
-                </div>
-                <div class="theme-field theme-form__span-full">
-                  <label for="create-role" class="theme-label">权限</label>
-                  <select
-                    id="create-role"
-                    name="is_admin"
-                    class="theme-input"
-                  >
-                    <option value="0" selected>普通用户</option>
-                    <option value="1">管理员</option>
-                  </select>
                 </div>
               </div>
               <div class="theme-form__footer theme-form__footer--center">

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -8,29 +8,42 @@
       data-success-event="refresh-users"
     >
       <div class="theme-form__grid theme-form__grid--two-fixed">
-        <div class="theme-field">
-          <label for="edit-username-{{ item.id }}" class="theme-label">用户名</label>
-          <input
-            id="edit-username-{{ item.id }}"
-            name="username"
-            type="text"
-            required
-            value="{{ item.username }}"
-            class="theme-input"
-            autocomplete="off"
-            spellcheck="false"
-          />
-        </div>
-        <div class="theme-field">
-          <label for="edit-email-{{ item.id }}" class="theme-label">邮箱</label>
-          <input
-            id="edit-email-{{ item.id }}"
-            name="email"
-            type="email"
-            required
-            value="{{ item.email }}"
-            class="theme-input"
-          />
+        <div class="theme-form__grid theme-form__grid--user-identity theme-form__span-full">
+          <div class="theme-field">
+            <label for="edit-username-{{ item.id }}" class="theme-label">用户名</label>
+            <input
+              id="edit-username-{{ item.id }}"
+              name="username"
+              type="text"
+              required
+              value="{{ item.username }}"
+              class="theme-input"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
+          <div class="theme-field">
+            <label for="edit-email-{{ item.id }}" class="theme-label">邮箱</label>
+            <input
+              id="edit-email-{{ item.id }}"
+              name="email"
+              type="email"
+              required
+              value="{{ item.email }}"
+              class="theme-input"
+            />
+          </div>
+          <div class="theme-field">
+            <label for="edit-role-{{ item.id }}" class="theme-label">权限</label>
+            <select
+              id="edit-role-{{ item.id }}"
+              name="is_admin"
+              class="theme-input theme-input--compact"
+            >
+              <option value="0" {% if not item.is_admin %}selected{% endif %}>普通用户</option>
+              <option value="1" {% if item.is_admin %}selected{% endif %}>管理员</option>
+            </select>
+          </div>
         </div>
         <div class="theme-field">
           <label for="edit-password-{{ item.id }}" class="theme-label">新密码</label>
@@ -53,17 +66,6 @@
             class="theme-input"
             placeholder="再次输入新密码"
           />
-        </div>
-        <div class="theme-field theme-form__span-full">
-          <label for="edit-role-{{ item.id }}" class="theme-label">权限</label>
-          <select
-            id="edit-role-{{ item.id }}"
-            name="is_admin"
-            class="theme-input"
-          >
-            <option value="0" {% if not item.is_admin %}selected{% endif %}>普通用户</option>
-            <option value="1" {% if item.is_admin %}selected{% endif %}>管理员</option>
-          </select>
         </div>
       </div>
       <div class="theme-form__footer">

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -824,6 +824,17 @@
         }
       }
 
+      .theme-form__grid--user-identity {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+        align-items: end;
+      }
+
+      @media (max-width: 640px) {
+        .theme-form__grid--user-identity {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+
       .theme-form__grid--three {
         grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       }
@@ -922,6 +933,17 @@
         color: var(--theme-text-primary);
         font-size: 0.95rem;
         transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+      }
+
+      .theme-input--compact {
+        width: 6.5rem;
+        min-width: 0;
+      }
+
+      @media (max-width: 640px) {
+        .theme-input--compact {
+          width: 100%;
+        }
       }
 
       .theme-input:focus,


### PR DESCRIPTION
## Summary
- align the permission selector with the username and email fields in the admin user forms
- add a compact input style and responsive grid helper for the inline permission selector

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e132178138832f83d578ade0814782