### PR TITLE
Adjust user creation form layout

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -825,13 +825,14 @@
       }
 
       .theme-form__grid--user-identity {
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(10rem, auto);
         align-items: end;
       }
 
       .theme-form__grid--user-identity .theme-field {
         width: 100%;
         max-width: none;
+        min-width: 0;
         justify-self: stretch;
       }
 


### PR DESCRIPTION
## Summary
- widen the user creation form grid's third column to reserve space for the role selector
- allow identity fields within the grid to shrink without overflowing the permission dropdown

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e145faabdc832f90a158806a269c16