### PR TITLE
Adjust mobile admin login alignment

### DIFF
--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -4,10 +4,10 @@
 <div class="theme-layout">
   <section class="theme-shell">
     <div class="theme-shell__body theme-shell__body--center">
-      <section class="theme-card theme-card--narrow">
+      <section class="theme-card theme-card--narrow theme-card--auth">
         <div class="theme-card__header theme-card__header--center">
           <h2 class="theme-card__title">登录 yet.la 短链子域管理后台</h2>
-          <p class="theme-card__subtitle">输入管理员账号与密码以继续管理短链与子域。</p>
+          <p class="theme-card__subtitle">输入管理员账号与密码</p>
         </div>
         <div class="theme-card__body">
           <form

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -831,8 +831,7 @@
       }
 
       .theme-form--login .theme-field {
-        width: 100%;
-        max-width: 320px;
+        width: min(100%, 18.75rem);
         margin-left: auto;
         margin-right: auto;
         align-items: stretch;
@@ -857,8 +856,7 @@
       }
 
       .theme-form--login .theme-form__footer {
-        width: 100%;
-        max-width: 320px;
+        width: min(100%, 18.75rem);
         margin-left: auto;
         margin-right: auto;
         align-items: stretch;
@@ -866,6 +864,15 @@
 
       .theme-form--login .theme-button--block {
         max-width: none;
+        width: 100%;
+      }
+
+      .theme-card--auth .theme-card__header {
+        padding-bottom: 1.35rem;
+      }
+
+      .theme-card--auth .theme-card__subtitle {
+        margin-top: 0.6rem;
       }
 
       .theme-form__grid {
@@ -1518,15 +1525,19 @@
         .theme-hero__title {
           font-size: clamp(1.35rem, 6vw, 1.65rem);
           line-height: 1.2;
+          text-align: center;
         }
 
         .theme-hero__heading {
           width: 100%;
+          align-items: center;
+          text-align: center;
         }
 
         .theme-hero__title-row {
           width: 100%;
-          justify-content: space-between;
+          justify-content: center;
+          gap: 0.5rem;
         }
 
         .theme-hero__title-text--full {
@@ -1542,6 +1553,16 @@
           align-items: center;
           justify-content: center;
           flex-shrink: 0;
+        }
+
+        .theme-hero__top {
+          align-items: center;
+          margin-bottom: 0.75rem;
+        }
+
+        .theme-hero__brand {
+          margin-left: auto;
+          margin-right: auto;
         }
 
         .theme-hero__actions {


### PR DESCRIPTION
## Summary
- center the mobile hero heading and reduce spacing beneath the title
- constrain the admin login form controls and simplify the helper copy

## Testing
- pytest backend/tests/test_auth.py::test_login_flow_success --maxfail=1

------
https://chatgpt.com/codex/tasks/task_b_68e1e4607f20832f8edb1c732efe5728