### PR TITLE
Adjust admin login spacing

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -746,8 +746,8 @@
       .theme-shell__body--center {
         display: flex;
         justify-content: center;
-        padding-top: 3rem;
-        padding-bottom: 3rem;
+        padding-top: 1.85rem;
+        padding-bottom: 2.1rem;
       }
 
       .theme-stack {
@@ -807,10 +807,10 @@
       }
 
       .theme-card__body {
-        padding: 2.25rem;
+        padding: 1.85rem 2.1rem;
         display: flex;
         flex-direction: column;
-        gap: 1.75rem;
+        gap: 1.5rem;
       }
 
       .theme-card__body--table {
@@ -828,10 +828,11 @@
       .theme-form--login {
         align-items: stretch;
         text-align: left;
+        gap: 1.25rem;
       }
 
       .theme-form--login .theme-field {
-        width: min(100%, 18.75rem);
+        width: min(100%, 16.5rem);
         margin-left: auto;
         margin-right: auto;
         align-items: stretch;
@@ -856,7 +857,7 @@
       }
 
       .theme-form--login .theme-form__footer {
-        width: min(100%, 18.75rem);
+        width: min(100%, 16.5rem);
         margin-left: auto;
         margin-right: auto;
         align-items: stretch;
@@ -1476,7 +1477,7 @@
         }
 
         .theme-shell__body--center {
-          padding: 2rem 1.5rem 2.25rem;
+          padding: 1.7rem 1.5rem 2rem;
         }
 
         .theme-card {
@@ -1488,7 +1489,7 @@
         }
 
         .theme-card__body {
-          padding: 1.5rem;
+          padding: 1.35rem 1.5rem 1.4rem;
         }
 
         .theme-tabs {
@@ -1592,7 +1593,7 @@
         }
 
         .theme-shell__body--center {
-          padding: 1.5rem 0.9rem 1.9rem;
+          padding: 1.35rem 0.9rem 1.65rem;
         }
 
         .theme-card--narrow {
@@ -1604,7 +1605,7 @@
         }
 
         .theme-card__body {
-          padding: 1.2rem;
+          padding: 1.05rem 1.15rem 1.15rem;
         }
 
         .theme-card__subtitle {


### PR DESCRIPTION
## Summary
- reduce the top and bottom padding around the admin login card to tighten the layout on both desktop and mobile viewports
- shrink the login form spacing and field width so inputs are shorter and the form feels more compact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e1eb7925a8832fb57efef2fe91725d