### PR TITLE
Adjust login form input width on mobile

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -832,7 +832,7 @@
       }
 
       .theme-form--login .theme-field {
-        width: min(100%, 16.5rem);
+        width: min(100%, 14.5rem);
         margin-left: auto;
         margin-right: auto;
         align-items: stretch;
@@ -857,7 +857,7 @@
       }
 
       .theme-form--login .theme-form__footer {
-        width: min(100%, 16.5rem);
+        width: min(100%, 14.5rem);
         margin-left: auto;
         margin-right: auto;
         align-items: stretch;


### PR DESCRIPTION
## Summary
- reduce the login form field and footer width to prevent input overflow on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e1f2e4e9b0832fb59fd66debac486f