### PR TITLE
Adjust mobile hero header spacing

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1427,18 +1427,18 @@
 
       @media (max-width: 768px) {
         header.theme-hero {
-          padding: 2.25rem 1.25rem 1.75rem;
+          padding: 1.65rem 1.25rem 1.2rem;
         }
 
         .theme-hero__inner {
-          padding: 2rem 1.5rem;
+          padding: 1.6rem 1.4rem;
           border-radius: var(--radius-md);
         }
 
         .theme-hero__top {
           flex-direction: column;
           align-items: flex-start;
-          gap: 1.25rem;
+          gap: 1rem;
         }
 
         .theme-hero__actions {
@@ -1516,11 +1516,11 @@
         }
 
         header.theme-hero {
-          padding: 1.85rem 0.9rem 1.5rem;
+          padding: 1.35rem 0.9rem 0.95rem;
         }
 
         .theme-hero__inner {
-          padding: 1.75rem 1.1rem;
+          padding: 1.35rem 1rem;
         }
 
         .theme-hero__title {
@@ -1558,7 +1558,7 @@
 
         .theme-hero__top {
           align-items: center;
-          margin-bottom: 0.75rem;
+          margin-bottom: 0.55rem;
         }
 
         .theme-hero__brand {
@@ -1567,7 +1567,7 @@
         }
 
         .theme-hero__actions {
-          gap: 0.6rem;
+          gap: 0.5rem;
         }
 
         .theme-hero__actions .theme-theme-switch {


### PR DESCRIPTION
## Summary
- tighten the admin hero header padding on mobile breakpoints to shrink unused vertical space
- reduce gaps in the hero header mobile layout so the content stays compact without affecting desktop styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e1f893aeb0832f9910c3aaea494164