### PR TITLE
Improve admin settings HTMX handling and short link routing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -440,13 +440,28 @@ async def update_site_settings_endpoint(
     """更新站点设置（管理员限定）。"""
 
     settings = update_site_settings(db, **payload.model_dump())
+    short_link_prefix = build_short_link_prefix(settings)
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        redirect_url = "/admin?tab=settings&saved=1"
+        feedback_html = (
+            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
+            "站点设置已更新"
+            "</div>"
+        )
+        template = admin_templates.get_template("admin/partials/settings_card.html")
+        content = template.render(
+            {
+                "request": request,
+                "site_settings": settings,
+                "short_link_prefix": short_link_prefix,
+                "short_link_example": f"{short_link_prefix}example",
+                "settings_feedback_html": feedback_html,
+            }
+        )
         return HTMLResponse(
-            "",
-            status_code=status.HTTP_204_NO_CONTENT,
-            headers={"HX-Redirect": redirect_url},
+            content,
+            status_code=status.HTTP_200_OK,
+            headers={"HX-Trigger": "settings-updated"},
         )
 
     response.headers["HX-Trigger"] = "settings-updated"
@@ -957,17 +972,6 @@ def catch_all(
         return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
     host = raw_host.split(":", 1)[0]
 
-    redirect = db.scalar(select(SubdomainRedirect).where(SubdomainRedirect.host == host))
-    if redirect is not None:
-        redirect.hits += 1
-        db.add(redirect)
-        _commit_session(db)
-
-        destination = _compose_redirect_target(
-            redirect.target_url, path=path, query=request.url.query or ""
-        )
-        return RedirectResponse(destination, status_code=redirect.code)
-
     settings = get_site_settings(db)
     allow_short_link = host == settings.site_domain.strip().lower()
 
@@ -985,5 +989,16 @@ def catch_all(
             return RedirectResponse(
                 short_link.target_url, status_code=status.HTTP_302_FOUND
             )
+
+    redirect = db.scalar(select(SubdomainRedirect).where(SubdomainRedirect.host == host))
+    if redirect is not None:
+        redirect.hits += 1
+        db.add(redirect)
+        _commit_session(db)
+
+        destination = _compose_redirect_target(
+            redirect.target_url, path=path, query=request.url.query or ""
+        )
+        return RedirectResponse(destination, status_code=redirect.code)
 
     return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -49,3 +49,27 @@ def test_update_settings_affects_short_links(client: "SimpleClient") -> None:
 
     missing = client.get("/jump", headers={"host": "example.com"}, follow_redirects=False)
     assert missing.status_code == 404
+
+
+def test_update_settings_via_htmx_returns_partial(client: "SimpleClient") -> None:
+    payload = {
+        "site_domain": "yet.la",
+        "short_code_length": "6",
+        "short_link_path": "/a/",
+        "logo_url": "https://cdn.example.com/logo-alt.png",
+        "icon_url": "https://cdn.example.com/icon-alt.png",
+    }
+
+    response = client.put(
+        "/api/settings",
+        data=payload,
+        headers={"hx-request": "true"},
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("hx-trigger") == "settings-updated"
+    assert "站点设置已更新" in response.text
+    assert "id=\"site-settings-card\"" in response.text
+    assert "value=\"/a/\"" in response.text

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -165,6 +165,39 @@ def test_short_links_are_scoped_by_user(client: "SimpleClient") -> None:
     assert admin_codes == {"admin-link", "alice"}
 
 
+def test_short_link_precedence_over_subdomain_redirect(
+    client: "SimpleClient",
+) -> None:
+    redirect_response = client.post(
+        "/api/subdomains",
+        json={
+            "host": "yet.la",
+            "target_url": "https://portal.example.com/admin",
+            "code": 302,
+        },
+        auth=ADMIN_AUTH,
+    )
+    assert redirect_response.status_code == 201
+
+    client.post(
+        "/api/links",
+        json={"target_url": "https://example.com/home", "code": "portal"},
+        auth=ADMIN_AUTH,
+    )
+
+    short_redirect = client.get(
+        "/portal",
+        headers={"host": "yet.la"},
+        follow_redirects=False,
+    )
+    assert short_redirect.status_code == 302
+    assert short_redirect.headers["location"] == "https://example.com/home"
+
+    homepage = client.get("/", headers={"host": "yet.la"}, follow_redirects=False)
+    assert homepage.status_code == 302
+    assert homepage.headers["location"].startswith("https://portal.example.com/admin")
+
+
 def test_non_admin_cannot_modify_other_users_links(client: "SimpleClient") -> None:
     admin_link = client.post(
         "/api/links",


### PR DESCRIPTION
## Summary
- render the updated settings card when the admin saves via HTMX instead of issuing an HX redirect
- evaluate short link requests before subdomain redirects so the configured domain keeps working even with overlapping rules
- add regression tests for the HTMX response and short link precedence

## Testing
- pytest backend/tests/test_settings.py backend/tests/test_short_links.py

------
https://chatgpt.com/codex/tasks/task_b_68e3a27b8d80832fa791838e31d13ce9