### PR TITLE
Fix short link redirects for www host

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,6 +55,7 @@ from .settings_service import (
     ensure_default_settings,
     extract_short_code,
     get_site_settings,
+    resolve_short_link_hosts,
     update_site_settings,
 )
 
@@ -973,7 +974,8 @@ def catch_all(
     host = raw_host.split(":", 1)[0]
 
     settings = get_site_settings(db)
-    allow_short_link = host == settings.site_domain.strip().lower()
+    short_link_hosts = resolve_short_link_hosts(settings)
+    allow_short_link = host in short_link_hosts
 
     if allow_short_link and request.method in {"GET", "HEAD"}:
         code = extract_short_code(path, settings)

--- a/backend/app/settings_service.py
+++ b/backend/app/settings_service.py
@@ -49,6 +49,22 @@ def normalize_short_link_path(value: str | None) -> str:
     return normalized
 
 
+def resolve_short_link_hosts(settings: SiteSettings) -> set[str]:
+    """Return hostnames that should trigger short link lookups."""
+
+    canonical = (settings.site_domain or "").strip().lower()
+    if not canonical:
+        return set()
+
+    hosts = {canonical}
+    if canonical.startswith("www."):
+        hosts.add(canonical[4:])
+    else:
+        hosts.add(f"www.{canonical}")
+
+    return {host for host in hosts if host}
+
+
 def normalize_short_code_length(value: int | None) -> int:
     length = value or DEFAULT_SHORT_CODE_LENGTH
     if length < _MIN_SHORT_CODE_LENGTH:

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -50,6 +50,62 @@ def test_redirect_short_link_and_hits(client: "SimpleClient") -> None:
     assert records[0]["hits"] == 1
 
 
+def test_redirect_short_link_with_admin_prefix(client: "SimpleClient") -> None:
+    update = client.put(
+        "/api/settings",
+        data={
+            "site_domain": "yet.la",
+            "short_code_length": "6",
+            "short_link_path": "/admin/",
+            "logo_url": "https://img.example.com/logo.png",
+            "icon_url": "https://img.example.com/icon.png",
+        },
+        auth=ADMIN_AUTH,
+    )
+    assert update.status_code == 200
+
+    create = client.post(
+        "/api/links",
+        json={"target_url": "https://example.org/landing", "code": "promo"},
+        auth=ADMIN_AUTH,
+    )
+    assert create.status_code == 201
+
+    redirect = client.get(
+        "/admin/promo",
+        headers={"host": "yet.la"},
+        follow_redirects=False,
+    )
+    assert redirect.status_code == 302
+    assert redirect.headers["location"] == "https://example.org/landing"
+
+
+def test_short_link_redirect_handles_www_host(client: "SimpleClient") -> None:
+    client.post(
+        "/api/links",
+        json={"target_url": "https://example.net/home", "code": "promo"},
+        auth=ADMIN_AUTH,
+    )
+
+    client.post(
+        "/api/subdomains",
+        json={
+            "host": "www.yet.la",
+            "target_url": "https://yet.la/admin",
+            "code": 302,
+        },
+        auth=ADMIN_AUTH,
+    )
+
+    redirect = client.get(
+        "/promo",
+        headers={"host": "www.yet.la"},
+        follow_redirects=False,
+    )
+    assert redirect.status_code == 302
+    assert redirect.headers["location"] == "https://example.net/home"
+
+
 def test_redirect_short_link_not_found(client: "SimpleClient") -> None:
     response = client.get("/missing", headers={"host": "yet.la"}, follow_redirects=False)
     assert response.status_code == 404


### PR DESCRIPTION
## Summary
- resolve the set of hostnames that should serve short links and include canonical/www variants
- reuse the host list in the catch-all redirect endpoint to avoid falling through to subdomain rules
- add regression coverage for admin-prefixed short links and www host requests

## Testing
- pytest backend/tests/test_short_links.py


------
https://chatgpt.com/codex/tasks/task_b_68e3a61d062c832f96373c2baf9bb78c