### PR TITLE
Fix fallback redirect loop on root domain

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1012,4 +1012,7 @@ def catch_all(
         )
         return RedirectResponse(destination, status_code=redirect.code)
 
+    if fallback_domain == host and not path.strip("/"):
+        return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
+
     return RedirectResponse(fallback_url, status_code=status.HTTP_302_FOUND)

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -112,6 +112,12 @@ def test_redirect_short_link_not_found(client: "SimpleClient") -> None:
     assert response.headers["location"] == "https://yet.la"
 
 
+def test_root_request_returns_not_found(client: "SimpleClient") -> None:
+    response = client.get("/", headers={"host": "yet.la"}, follow_redirects=False)
+    assert response.status_code == 404
+    assert response.text == "Not Found"
+
+
 def test_create_short_link_via_htmx_form(client: "SimpleClient") -> None:
     response = client.post(
         "/api/links",


### PR DESCRIPTION
## Summary
- avoid redirect loops when the fallback domain matches the current host without a path
- add a regression test covering the root-path not found response

## Testing
- pytest backend/tests/test_short_links.py

------
https://chatgpt.com/codex/tasks/task_b_68e3b23dfd3c832f9388226f80c1c718