### PR TITLE
Remove admin CDN dependencies to silence console errors

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -997,10 +997,6 @@
       return;
     }
 
-    console.warn(
-      "htmx 未加载，使用回退逻辑处理短链子域管理后台交互。\n建议检查 CDN 是否可访问。"
-    );
-
     refreshUsersHandler();
     refreshLinksHandler();
     refreshSubdomainsHandler();

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -11,12 +11,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.3/dist/tailwind.min.css"
-      integrity="sha384-4r7vpQCeYrOJvmSesi2atCkQ3pWhhi9z3pMsm9YaOGCE1zmdv8cE9VrjC2bX9msd"
-      crossorigin="anonymous"
-    />
     <script>
       (function () {
         var fallback = "aurora";
@@ -99,6 +93,19 @@
         --theme-copy-icon: rgba(148, 163, 184, 0.55);
         --theme-copy-icon-active: rgba(99, 102, 241, 0.95);
         --theme-copy-feedback: rgba(79, 70, 229, 0.95);
+      }
+
+      html,
+      body {
+        min-height: 100%;
+      }
+
+      .h-full {
+        height: 100%;
+      }
+
+      .bg-slate-50 {
+        background-color: #f8fafc;
       }
 
       :root[data-theme="nebula"] {
@@ -1671,12 +1678,6 @@
         background: rgba(148, 163, 184, 0.15);
       }
     </style>
-    <script
-      src="https://unpkg.com/htmx.org@1.9.10"
-      integrity="sha384-tPY/1+qsSVqSdz+CA0nVddOZXS6jttuPAHyBs+K6TfGsDz3jAC5vVsQt1zArhcXa"
-      crossorigin="anonymous"
-      defer
-    ></script>
     <script src="/static/admin-dashboard.js" defer></script>
     <script>
       document.addEventListener("htmx:configRequest", function (event) {


### PR DESCRIPTION
## Summary
- stop loading Tailwind and htmx from external CDNs in the admin base template
- add local utility CSS so the layout keeps the expected height and background styling
- rely on the existing fallback JS without logging warnings in the console

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e4839211e8832fb39c7519741c56ab