### PR TITLE
Suppress console warning when htmx fallback is active

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -924,6 +924,33 @@
   onReady(() => {
     const useFallback = typeof window.htmx === "undefined";
 
+    if (
+      useFallback &&
+      typeof console !== "undefined" &&
+      typeof console.warn === "function"
+    ) {
+      const originalWarn = console.warn.bind(console);
+      const fallbackNotices = [
+        "htmx 未加载，使用回退逻辑处理管理后台交互。",
+        "htmx 未加载，使用回退逻辑处理短链子域管理后台交互。",
+      ];
+      console.warn = (...args) => {
+        const combined = args
+          .filter((value) => typeof value === "string")
+          .join(" ")
+          .trim();
+
+        if (
+          combined &&
+          fallbackNotices.some((notice) => combined.includes(notice))
+        ) {
+          return;
+        }
+
+        originalWarn(...args);
+      };
+    }
+
     restorePersistedTheme();
     bindThemeToggles();
     bindMobileThemeToggle();


### PR DESCRIPTION
## Summary
- suppress the legacy htmx fallback warning in the admin dashboard by filtering the specific console message when the fallback logic is engaged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e485e9ea00832fb31cb59165535dad