### PR TITLE
Remove HTTPS scheme from short link display

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -82,7 +82,7 @@
                 <div class="theme-field">
                   <label for="code" class="theme-label">短链（可改）</label>
                   <div class="theme-input-affix">
-                    <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_prefix }}</span>
+                    <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_display_prefix }}</span>
                     <input
                       id="code"
                       name="code"

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -11,7 +11,7 @@
         <div class="theme-field">
           <label for="code-{{ item.id }}" class="theme-label">短链</label>
           <div class="theme-input-affix">
-            <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_prefix }}</span>
+            <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_display_prefix }}</span>
             <input
               id="code-{{ item.id }}"
               name="code"

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -10,7 +10,7 @@
       data-copy-value="{{ short_link_prefix }}{{ item.code }}"
       aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
     >
-      <span class="theme-copy__text">{{ short_link_prefix }}{{ item.code }}</span>
+      <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
       <span class="theme-copy__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24">
           <rect x="9" y="9" width="12" height="12" rx="2"></rect>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -86,11 +86,17 @@ def _base_context(
     base_domain = settings.site_domain.strip().strip("/") or settings.site_domain
     base_url = f"https://{base_domain}".rstrip("/")
     short_link_prefix = build_short_link_prefix(settings)
+    short_link_display_prefix = short_link_prefix
+    for scheme in ("https://", "http://"):
+        if short_link_display_prefix.startswith(scheme):
+            short_link_display_prefix = short_link_display_prefix[len(scheme) :]
+            break
     return {
         "request": request,
         "base_domain": base_domain,
         "base_url": base_url,
         "short_link_prefix": short_link_prefix,
+        "short_link_display_prefix": short_link_display_prefix,
         "short_code_length": settings.short_code_length,
         "site_settings": settings,
         "current_year": datetime.utcnow().year,


### PR DESCRIPTION
## Summary
- hide the HTTPS scheme before the short link prefix in the creation form and list rows
- add a display-only prefix derived from the full short link for templates while keeping copy values unchanged

## Testing
- pytest backend/tests/test_short_links.py::test_admin_short_link_partials

------
https://chatgpt.com/codex/tasks/task_b_68e48a1d3414832fa5f1c8170d027d85