### PR TITLE
Center admin table headers and constrain target URLs

### DIFF
--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -20,7 +20,9 @@
       <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
     </button>
   </td>
-  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted">{{ item.target_url }}</td>
+  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted theme-table__col-target">
+    <span class="theme-table__target-text">{{ item.target_url }}</span>
+  </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
   <td class="theme-table__cell theme-table__cell--muted">
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -3,13 +3,13 @@
   <thead>
     <tr>
       <th scope="col">短链</th>
-      <th scope="col">目标地址</th>
+      <th scope="col" class="theme-table__col-target">目标地址</th>
       <th scope="col">访问次数</th>
       <th scope="col">创建时间</th>
       {% if show_user_column %}
       <th scope="col">用户</th>
       {% endif %}
-      <th scope="col" class="theme-table__cell--right">操作</th>
+      <th scope="col">操作</th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -20,7 +20,9 @@
       <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
     </button>
   </td>
-  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted">{{ item.target_url }}</td>
+  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted theme-table__col-target">
+    <span class="theme-table__target-text">{{ item.target_url }}</span>
+  </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.code }}</td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
   <td class="theme-table__cell theme-table__cell--muted">

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -3,14 +3,14 @@
   <thead>
     <tr>
       <th scope="col">子域</th>
-      <th scope="col">目标地址</th>
+      <th scope="col" class="theme-table__col-target">目标地址</th>
       <th scope="col">状态码</th>
       <th scope="col">访问次数</th>
       <th scope="col">创建时间</th>
       {% if show_user_column %}
       <th scope="col">用户</th>
       {% endif %}
-      <th scope="col" class="theme-table__cell--right">操作</th>
+      <th scope="col">操作</th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/templates/admin/partials/user_table.html
+++ b/backend/app/templates/admin/partials/user_table.html
@@ -6,7 +6,7 @@
       <th scope="col">邮箱</th>
       <th scope="col">权限</th>
       <th scope="col">创建时间</th>
-      <th scope="col" class="theme-table__cell--right">操作</th>
+      <th scope="col">操作</th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1236,7 +1236,7 @@
       }
 
       .theme-table thead th {
-        text-align: left;
+        text-align: center;
         padding: 0.95rem 1.5rem;
         font-weight: 600;
         letter-spacing: 0.02em;
@@ -1244,6 +1244,16 @@
         font-size: 0.78rem;
         color: var(--theme-muted);
         background: var(--theme-table-head-bg);
+      }
+
+      .theme-table__col-target {
+        width: min(30rem, 70vw);
+      }
+
+      .theme-table__target-text {
+        display: inline-block;
+        max-width: min(30rem, 70vw);
+        word-break: break-all;
       }
 
       .theme-table tbody tr {


### PR DESCRIPTION
## Summary
- center align the column headers for the short link, subdomain, and user admin tables
- limit the short link and subdomain target URL column width with responsive styling to keep layouts readable

## Testing
- not run (template/CSS updates only)


------
https://chatgpt.com/codex/tasks/task_b_68e48cf01914832fa8137b2aa1daa516