### PR TITLE
Tighten admin target columns and add local htmx fallback

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -922,7 +922,8 @@
   }
 
   onReady(() => {
-    const useFallback = typeof window.htmx === "undefined";
+    const useFallback =
+      !window.htmx || window.htmx.__YETLA_USE_FALLBACK__ === true;
 
     if (
       useFallback &&

--- a/backend/app/static/vendor/htmx-lite.js
+++ b/backend/app/static/vendor/htmx-lite.js
@@ -1,0 +1,64 @@
+(function () {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (window.htmx && window.htmx.__YETLA_USE_FALLBACK__ !== true) {
+    return;
+  }
+
+  function toArray(value) {
+    if (Array.isArray(value)) {
+      return value.slice();
+    }
+    return [value];
+  }
+
+  function dispatch(target, eventName, detail) {
+    if (!(target instanceof EventTarget) || !eventName) {
+      return;
+    }
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      cancelable: true,
+      detail: detail || null,
+    });
+    target.dispatchEvent(event);
+  }
+
+  function onLoad(callback) {
+    if (typeof callback !== "function") {
+      return;
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function trigger(target, eventName, detail) {
+    if (!eventName) {
+      return;
+    }
+    const targets = target ? toArray(target) : [document.body];
+    targets.forEach((item) => {
+      if (item instanceof EventTarget) {
+        dispatch(item, eventName, detail);
+      }
+    });
+  }
+
+  window.htmx = {
+    version: "lite-0.1",
+    config: {
+      useFallback: true,
+    },
+    __YETLA_USE_FALLBACK__: true,
+    trigger,
+    onLoad,
+    off: function () {},
+    on: function () {},
+    process: function () {},
+  };
+})();

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1247,13 +1247,14 @@
       }
 
       .theme-table__col-target {
-        width: min(30rem, 70vw);
+        width: clamp(12rem, 28vw, 22rem);
       }
 
       .theme-table__target-text {
         display: inline-block;
-        max-width: min(30rem, 70vw);
+        max-width: clamp(12rem, 28vw, 22rem);
         word-break: break-all;
+        white-space: normal;
       }
 
       .theme-table tbody tr {
@@ -1446,6 +1447,12 @@
         .theme-tabs {
           padding: 2rem 1.75rem 0;
         }
+
+        .theme-table__col-target,
+        .theme-table__target-text {
+          width: clamp(10rem, 42vw, 18rem);
+          max-width: clamp(10rem, 42vw, 18rem);
+        }
       }
 
       @media (max-width: 768px) {
@@ -1524,6 +1531,12 @@
 
         .theme-tab {
           flex: 0 0 auto;
+        }
+
+        .theme-table__col-target,
+        .theme-table__target-text {
+          width: 100%;
+          max-width: 100%;
         }
       }
 
@@ -1688,6 +1701,7 @@
         background: rgba(148, 163, 184, 0.15);
       }
     </style>
+    <script src="/static/vendor/htmx-lite.js" defer></script>
     <script src="/static/admin-dashboard.js" defer></script>
     <script>
       document.addEventListener("htmx:configRequest", function (event) {


### PR DESCRIPTION
## Summary
- clamp the target-column widths in the admin tables for large and small breakpoints so the trailing columns stay readable
- load a lightweight local htmx stub before the dashboard script and detect it so the interface always uses the built-in fallback without CDN warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e49636a700832f8f05c1bb740b0bcf