### PR TITLE
Adjust subdomain target column width for admin table

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1247,12 +1247,12 @@
       }
 
       .theme-table__col-target {
-        width: clamp(12rem, 28vw, 22rem);
+        width: clamp(11rem, 24vw, 18rem);
       }
 
       .theme-table__target-text {
         display: inline-block;
-        max-width: clamp(12rem, 28vw, 22rem);
+        max-width: clamp(11rem, 24vw, 18rem);
         word-break: break-all;
         white-space: normal;
       }


### PR DESCRIPTION
## Summary
- narrow the subdomain target column width so the new visit count column fits without distortion

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e49a3a2570832fb81c427e87acb1af