### PR TITLE
Update mobile login copy and spacing

### DIFF
--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -6,8 +6,8 @@
     <div class="theme-shell__body theme-shell__body--center">
       <section class="theme-card theme-card--narrow theme-card--auth">
         <div class="theme-card__header theme-card__header--center">
-          <h2 class="theme-card__title">登录 {{ site_settings.site_domain }} 短链子域管理后台</h2>
-          <p class="theme-card__subtitle">输入管理员账号与密码</p>
+          <h2 class="theme-card__title">登录 {{ site_settings.site_domain }} 管理后台</h2>
+          <p class="theme-card__subtitle">输入账号与密码</p>
         </div>
         <div class="theme-card__body">
           <form

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1677,9 +1677,20 @@
 
         .theme-form--login .theme-field,
         .theme-form--login .theme-form__footer {
-          max-width: 100%;
-          margin-left: 0;
-          margin-right: 0;
+          width: clamp(11rem, 82vw, 13.5rem);
+          margin-left: auto;
+          margin-right: auto;
+        }
+
+        .theme-form--login .theme-form__footer {
+          align-items: center;
+        }
+
+        .theme-form--login .theme-button--block {
+          width: auto;
+          min-width: clamp(8.5rem, 70vw, 11.5rem);
+          margin-left: auto;
+          margin-right: auto;
         }
 
         .theme-tabs::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- simplify the login page headline and subtitle copy
- tweak the mobile form layout to reduce input width and center the submit button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e4a37afea0832f8bc3cd460d48bc55