### PR TITLE
Update header and login form layout

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -419,52 +419,6 @@
         display: none;
       }
 
-      .theme-hero__mobile-switch {
-        display: none;
-      }
-
-      .theme-toggle--mobile {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 2.25rem;
-        height: 2.25rem;
-        border-radius: 999px;
-        border: 1px solid var(--theme-button-border);
-        background: rgba(255, 255, 255, 0.18);
-        color: var(--theme-hero-text);
-        transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
-      }
-
-      .theme-toggle--mobile:focus-visible {
-        outline: none;
-        border-color: var(--theme-input-focus-border);
-        box-shadow: var(--theme-input-focus-shadow);
-      }
-
-      :root[data-theme="nebula"] .theme-toggle--mobile {
-        background: rgba(15, 23, 42, 0.45);
-        border-color: rgba(94, 234, 212, 0.25);
-        color: var(--theme-hero-text);
-      }
-
-      .theme-toggle--mobile svg {
-        width: 1.15rem;
-        height: 1.15rem;
-      }
-
-      .theme-toggle--mobile .theme-toggle__icon {
-        display: none;
-      }
-
-      .theme-toggle--mobile[data-next-theme="nebula"] .theme-toggle__icon--moon {
-        display: inline-flex;
-      }
-
-      .theme-toggle--mobile[data-next-theme="aurora"] .theme-toggle__icon--sun {
-        display: inline-flex;
-      }
-
       .theme-hero__subtitle {
         margin-top: 0.5rem;
         max-width: 620px;
@@ -1606,13 +1560,6 @@
           display: inline;
         }
 
-        .theme-hero__mobile-switch {
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          flex-shrink: 0;
-        }
-
         .theme-hero__top {
           align-items: center;
           margin-bottom: 0.55rem;
@@ -1694,7 +1641,7 @@
 
         .theme-form--login .theme-field,
         .theme-form--login .theme-form__footer {
-          width: clamp(11rem, 82vw, 13.5rem);
+          width: clamp(10.5rem, 70vw, 12rem);
           margin-left: auto;
           margin-right: auto;
         }
@@ -1705,7 +1652,7 @@
 
         .theme-form--login .theme-button--block {
           width: auto;
-          min-width: clamp(8.5rem, 70vw, 11.5rem);
+          min-width: clamp(8rem, 64vw, 10.5rem);
           margin-left: auto;
           margin-right: auto;
         }
@@ -1785,40 +1732,12 @@
             <div class="theme-hero__title-row">
               <h1 class="theme-hero__title">
                 <span class="theme-hero__title-text theme-hero__title-text--full"
-                  >https://{{ site_settings.site_domain }} 短链子域管理后台</span
+                  >{{ site_settings.site_domain }} 短链子域管理后台</span
                 >
                 <span class="theme-hero__title-text theme-hero__title-text--compact"
-                  >https://{{ site_settings.site_domain }} 短链子域管理后台</span
+                  >{{ site_settings.site_domain }} 短链子域管理后台</span
                 >
               </h1>
-              <div class="theme-hero__mobile-switch">
-                <button
-                  type="button"
-                  class="theme-toggle theme-toggle--mobile"
-                  data-theme-toggle-cycle
-                  data-next-theme="nebula"
-                  aria-label="切换到暗色主题"
-                >
-                  <span class="sr-only" data-theme-toggle-label>切换到暗色主题</span>
-                  <svg
-                    class="theme-toggle__icon theme-toggle__icon--moon"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z"></path>
-                  </svg>
-                  <svg
-                    class="theme-toggle__icon theme-toggle__icon--sun"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <circle cx="12" cy="12" r="5"></circle>
-                    <path
-                      d="M12 1v2m0 18v2m11-11h-2M3 12H1m16.95-6.95-1.41 1.41M8.46 17.54l-1.41 1.41M17.54 17.54l-1.41-1.41M7.05 7.05 5.64 5.64"
-                    ></path>
-                  </svg>
-                </button>
-              </div>
             </div>
           </div>
           <div class="theme-hero__actions">


### PR DESCRIPTION
## Summary
- remove the redundant mobile theme toggle in the dashboard header
- drop the https:// prefix from the header title so only the domain is shown
- tighten the mobile login form field sizing to prevent overflow on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4aba0cd14832f9640d1fcd6df271e