### PR TITLE
Improve admin mobile layout interactions

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -4,56 +4,60 @@
 <div class="theme-layout">
   <section class="theme-shell">
     <nav class="theme-tabs" aria-label="Sections">
-      <a
-        href="?tab=links"
-        class="theme-tab {% if active_tab == 'links' %}is-active{% endif %}"
-      >
-        <span class="theme-tab__dot"></span>
-        短链
-        <span
-          class="theme-tab__count"
-          id="short-link-count"
-          hx-get="/admin/links/count"
-          hx-trigger="load, refresh-links from:body"
-          hx-swap="outerHTML"
+      <div class="theme-tabs__group theme-tabs__group--primary">
+        <a
+          href="?tab=links"
+          class="theme-tab {% if active_tab == 'links' %}is-active{% endif %}"
         >
-          ({{ short_links|length }})
-        </span>
-      </a>
-      <a
-        href="?tab=subdomains"
-        class="theme-tab {% if active_tab == 'subdomains' %}is-active{% endif %}"
-      >
-        <span class="theme-tab__dot"></span>
-        子域
-        {% with count=subdomains|length %}
-        {% include "admin/partials/subdomain_count.html" %}
-        {% endwith %}
-      </a>
+          <span class="theme-tab__dot"></span>
+          短链
+          <span
+            class="theme-tab__count"
+            id="short-link-count"
+            hx-get="/admin/links/count"
+            hx-trigger="load, refresh-links from:body"
+            hx-swap="outerHTML"
+          >
+            ({{ short_links|length }})
+          </span>
+        </a>
+        <a
+          href="?tab=subdomains"
+          class="theme-tab {% if active_tab == 'subdomains' %}is-active{% endif %}"
+        >
+          <span class="theme-tab__dot"></span>
+          子域
+          {% with count=subdomains|length %}
+          {% include "admin/partials/subdomain_count.html" %}
+          {% endwith %}
+        </a>
+      </div>
       {% if current_user and current_user.is_admin %}
-      <a
-        href="?tab=users"
-        class="theme-tab {% if active_tab == 'users' %}is-active{% endif %}"
-      >
-        <span class="theme-tab__dot"></span>
-        用户
-        <span
-          class="theme-tab__count"
-          id="user-count"
-          hx-get="/admin/users/count"
-          hx-trigger="load, refresh-users from:body"
-          hx-swap="outerHTML"
+      <div class="theme-tabs__group theme-tabs__group--secondary">
+        <a
+          href="?tab=users"
+          class="theme-tab {% if active_tab == 'users' %}is-active{% endif %}"
         >
-          ({{ users|length }})
-        </span>
-      </a>
-      <a
-        href="?tab=settings"
-        class="theme-tab {% if active_tab == 'settings' %}is-active{% endif %}"
-      >
-        <span class="theme-tab__dot"></span>
-        设置
-      </a>
+          <span class="theme-tab__dot"></span>
+          用户
+          <span
+            class="theme-tab__count"
+            id="user-count"
+            hx-get="/admin/users/count"
+            hx-trigger="load, refresh-users from:body"
+            hx-swap="outerHTML"
+          >
+            ({{ users|length }})
+          </span>
+        </a>
+        <a
+          href="?tab=settings"
+          class="theme-tab {% if active_tab == 'settings' %}is-active{% endif %}"
+        >
+          <span class="theme-tab__dot"></span>
+          设置
+        </a>
+      </div>
       {% endif %}
     </nav>
     <div class="theme-shell__body">

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -6,7 +6,7 @@
     <div class="theme-shell__body theme-shell__body--center">
       <section class="theme-card theme-card--narrow theme-card--auth">
         <div class="theme-card__header theme-card__header--center">
-          <h2 class="theme-card__title">登录 {{ site_settings.site_domain }} 管理后台</h2>
+          <h2 class="theme-card__title">登录 {{ site_settings.site_domain }} 短链子域管理后台</h2>
           <p class="theme-card__subtitle">输入账号与密码</p>
         </div>
         <div class="theme-card__body">

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -33,7 +33,7 @@
   </td>
   {% endif %}
   <td class="theme-table__cell theme-table__cell--right">
-    <div class="theme-table__actions">
+    <div class="theme-table__actions theme-table__actions--desktop">
       <button
         type="button"
         class="theme-button theme-button--ghost theme-button--sm"
@@ -55,5 +55,65 @@
         删除
       </button>
     </div>
+    <details class="theme-table__details">
+      <summary class="theme-table__details-toggle">
+        <span class="theme-button theme-button--ghost theme-button--sm">操作</span>
+      </summary>
+      <div class="theme-table__details-panel">
+        <dl class="theme-table__details-list">
+          <div class="theme-table__details-item">
+            <dt>目标地址</dt>
+            <dd>
+              <a
+                href="{{ item.target_url }}"
+                class="theme-table__details-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ item.target_url }}
+              </a>
+            </dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>访问次数</dt>
+            <dd>{{ item.hits }}</dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>创建时间</dt>
+            <dd>
+              {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+            </dd>
+          </div>
+          {% if show_user_column %}
+          <div class="theme-table__details-item">
+            <dt>用户</dt>
+            <dd>{{ item.owner_username or '—' }}</dd>
+          </div>
+          {% endif %}
+        </dl>
+        <div class="theme-table__details-actions">
+          <button
+            type="button"
+            class="theme-button theme-button--ghost theme-button--sm"
+            hx-get="/admin/links/{{ item.id }}/edit"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+          >
+            编辑
+          </button>
+          <button
+            type="button"
+            class="theme-button theme-button--danger theme-button--sm"
+            hx-delete="/api/links/{{ item.id }}"
+            hx-target="#link-feedback"
+            hx-swap="innerHTML"
+            hx-confirm="确认删除该短链？"
+            data-success-event="refresh-links"
+          >
+            删除
+          </button>
+        </div>
+      </div>
+    </details>
   </td>
 </tr>

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -32,7 +32,7 @@
   <td class="theme-table__cell theme-table__cell--muted">{{ item.owner_username or '—' }}</td>
   {% endif %}
   <td class="theme-table__cell theme-table__cell--right">
-    <div class="theme-table__actions">
+    <div class="theme-table__actions theme-table__actions--desktop">
       <button
         type="button"
         class="theme-button theme-button--ghost theme-button--sm"
@@ -54,5 +54,69 @@
         删除
       </button>
     </div>
+    <details class="theme-table__details">
+      <summary class="theme-table__details-toggle">
+        <span class="theme-button theme-button--ghost theme-button--sm">操作</span>
+      </summary>
+      <div class="theme-table__details-panel">
+        <dl class="theme-table__details-list">
+          <div class="theme-table__details-item">
+            <dt>目标地址</dt>
+            <dd>
+              <a
+                href="{{ item.target_url }}"
+                class="theme-table__details-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ item.target_url }}
+              </a>
+            </dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>状态码</dt>
+            <dd>{{ item.code }}</dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>访问次数</dt>
+            <dd>{{ item.hits }}</dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>创建时间</dt>
+            <dd>
+              {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+            </dd>
+          </div>
+          {% if show_user_column %}
+          <div class="theme-table__details-item">
+            <dt>用户</dt>
+            <dd>{{ item.owner_username or '—' }}</dd>
+          </div>
+          {% endif %}
+        </dl>
+        <div class="theme-table__details-actions">
+          <button
+            type="button"
+            class="theme-button theme-button--ghost theme-button--sm"
+            hx-get="/admin/subdomains/{{ item.id }}/edit"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+          >
+            编辑
+          </button>
+          <button
+            type="button"
+            class="theme-button theme-button--danger theme-button--sm"
+            hx-delete="/api/subdomains/{{ item.id }}"
+            hx-target="#subdomain-feedback"
+            hx-swap="innerHTML"
+            hx-confirm="确认删除该子域？"
+            data-success-event="refresh-subdomains"
+          >
+            删除
+          </button>
+        </div>
+      </div>
+    </details>
   </td>
 </tr>

--- a/backend/app/templates/admin/partials/user_row.html
+++ b/backend/app/templates/admin/partials/user_row.html
@@ -18,7 +18,7 @@
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
   </td>
   <td class="theme-table__cell theme-table__cell--right">
-    <div class="theme-table__actions">
+    <div class="theme-table__actions theme-table__actions--desktop">
       <button
         type="button"
         class="theme-button theme-button--ghost theme-button--sm"
@@ -40,5 +40,56 @@
         删除
       </button>
     </div>
+    <details class="theme-table__details">
+      <summary class="theme-table__details-toggle">
+        <span class="theme-button theme-button--ghost theme-button--sm">操作</span>
+      </summary>
+      <div class="theme-table__details-panel">
+        <dl class="theme-table__details-list">
+          <div class="theme-table__details-item">
+            <dt>邮箱</dt>
+            <dd>{{ item.email }}</dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>权限</dt>
+            <dd>
+              {% if item.is_admin %}
+              管理员
+              {% else %}
+              普通用户
+              {% endif %}
+            </dd>
+          </div>
+          <div class="theme-table__details-item">
+            <dt>创建时间</dt>
+            <dd>
+              {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+            </dd>
+          </div>
+        </dl>
+        <div class="theme-table__details-actions">
+          <button
+            type="button"
+            class="theme-button theme-button--ghost theme-button--sm"
+            hx-get="/admin/users/{{ item.id }}/edit"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+          >
+            编辑
+          </button>
+          <button
+            type="button"
+            class="theme-button theme-button--danger theme-button--sm"
+            hx-delete="/api/users/{{ item.id }}"
+            hx-target="#user-feedback"
+            hx-swap="innerHTML"
+            hx-confirm="确认删除该用户？"
+            data-success-event="refresh-users"
+          >
+            删除
+          </button>
+        </div>
+      </div>
+    </details>
   </td>
 </tr>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -667,6 +667,17 @@
         padding: 2.25rem var(--theme-container-padding) 0;
       }
 
+      .theme-tabs__group {
+        display: inline-flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .theme-tabs__group--secondary {
+        margin-left: auto;
+      }
+
       .theme-tab {
         display: inline-flex;
         align-items: center;
@@ -1281,6 +1292,86 @@
         gap: 0.75rem;
       }
 
+      .theme-table__actions--desktop {
+        display: flex;
+      }
+
+      .theme-table__details {
+        display: none;
+        margin-left: auto;
+      }
+
+      .theme-table__details-toggle {
+        list-style: none;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .theme-table__details-toggle::-webkit-details-marker {
+        display: none;
+      }
+
+      .theme-table__details-panel {
+        margin-top: 0.75rem;
+        padding: 0.75rem 0.9rem;
+        border-radius: var(--radius-sm);
+        background: var(--theme-surface-strong);
+        border: 1px solid var(--theme-surface-border);
+        box-shadow: var(--shadow-soft);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        min-width: min(100%, 18rem);
+        text-align: left;
+      }
+
+      .theme-table__details-list {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+
+      .theme-table__details-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .theme-table__details-item dt {
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+        color: var(--theme-muted);
+      }
+
+      .theme-table__details-item dd {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--theme-text-primary);
+        word-break: break-all;
+      }
+
+      .theme-table__details-link {
+        color: var(--theme-primary-strong);
+        text-decoration: none;
+        word-break: break-all;
+      }
+
+      .theme-table__details-link:hover,
+      .theme-table__details-link:focus-visible {
+        text-decoration: underline;
+      }
+
+      .theme-table__details-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.6rem;
+      }
+
       .theme-copy {
         display: inline-flex;
         align-items: center;
@@ -1572,6 +1663,11 @@
 
         .theme-hero__actions {
           gap: 0.5rem;
+          flex-direction: row;
+          align-items: center;
+          justify-content: flex-end;
+          flex-wrap: nowrap;
+          width: 100%;
         }
 
         .theme-hero__subtitle {
@@ -1581,6 +1677,18 @@
         .theme-tabs {
           padding: 1.1rem 1.05rem 0;
           gap: 0.6rem;
+          flex-wrap: wrap;
+          overflow-x: visible;
+        }
+
+        .theme-tabs__group {
+          width: 100%;
+          justify-content: flex-start;
+          gap: 0.6rem;
+        }
+
+        .theme-tabs__group--secondary {
+          margin-left: 0;
         }
 
         .theme-tab {
@@ -1621,6 +1729,30 @@
           padding: 0.85rem 1rem;
         }
 
+        .theme-table thead th:not(:first-child):not(:last-child),
+        .theme-table tbody td:not(:first-child):not(:last-child) {
+          display: none;
+        }
+
+        .theme-table__actions--desktop {
+          display: none;
+        }
+
+        .theme-table__details {
+          display: block;
+        }
+
+        .theme-table__details-panel {
+          width: 100%;
+          max-width: none;
+          box-shadow: none;
+          background: var(--theme-surface);
+        }
+
+        .theme-table__details-actions {
+          justify-content: flex-end;
+        }
+
         .theme-login-feedback {
           max-width: none;
         }
@@ -1637,6 +1769,41 @@
 
         .theme-button {
           width: 100%;
+        }
+
+        .theme-hero__actions .theme-button,
+        .theme-form__actions .theme-button,
+        .theme-table__details-toggle .theme-button,
+        .theme-table__details-actions .theme-button {
+          width: auto;
+          min-width: 0;
+        }
+
+        .theme-table__row--editing .theme-form__grid,
+        .theme-table__row--editing .theme-form__grid--two,
+        .theme-table__row--editing .theme-form__grid--three,
+        .theme-table__row--editing .theme-form__grid--two-fixed,
+        .theme-table__row--editing .theme-form__grid--user-identity {
+          grid-template-columns: minmax(0, 1fr);
+        }
+
+        .theme-table__row--editing .theme-field {
+          max-width: none;
+          width: 100%;
+        }
+
+        .theme-table__row--editing .theme-input,
+        .theme-table__row--editing .theme-input-affix,
+        .theme-table__row--editing .theme-input-affix__input,
+        .theme-table__row--editing .theme-select {
+          width: 100%;
+        }
+
+        .theme-table__row--editing .theme-form__actions {
+          justify-content: flex-end;
+          gap: 0.5rem;
+          width: auto;
+          align-self: flex-end;
         }
 
         .theme-form--login .theme-field,
@@ -1746,7 +1913,7 @@
               class="theme-button theme-button--ghost theme-button--password"
               href="/admin/password"
             >
-              修改密码
+              改密
             </a>
             <a
               class="theme-button theme-button--ghost theme-button--logout"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -30,7 +30,7 @@ def test_login_flow_success(client: "SimpleClient") -> None:
     )
     assert response.status_code == 200
     assert "创建短链" in response.text
-    assert "修改密码" in response.text
+    assert "改密" in response.text
 
     dashboard = client.get("/admin", follow_redirects=False)
     assert dashboard.status_code == 200


### PR DESCRIPTION
## Summary
- group the admin navigation tabs so that Users/Settings wrap onto a new row on mobile and adjust the header action copy to “改密”
- tweak the mobile styles to right-align the header buttons, shrink small buttons, and hide nonessential table columns while providing expandable detail panels for each row
- update the login headline and auth flow test expectations to reflect the new copy

## Testing
- pytest backend/tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_b_68e4b488eb3c832fac7d31a8bf926721