### PR TITLE
Improve mobile admin layout and action toggles

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -900,10 +900,14 @@
     }
 
     if (isOpen) {
+      details.open = true;
       details.setAttribute("open", "");
     } else {
+      details.open = false;
       details.removeAttribute("open");
     }
+
+    details.classList.toggle("is-open", Boolean(isOpen));
 
     if (summary instanceof HTMLElement) {
       summary.setAttribute("aria-expanded", isOpen ? "true" : "false");

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -9,7 +9,16 @@
       {% if show_user_column %}
       <th scope="col">用户</th>
       {% endif %}
-      <th scope="col">操作</th>
+      <th scope="col" class="theme-table__col-actions">
+        <span class="theme-table__col-actions-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="5" cy="12" r="1.8"></circle>
+            <circle cx="12" cy="12" r="1.8"></circle>
+            <circle cx="19" cy="12" r="1.8"></circle>
+          </svg>
+        </span>
+        <span class="sr-only">操作</span>
+      </th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -10,7 +10,16 @@
       {% if show_user_column %}
       <th scope="col">用户</th>
       {% endif %}
-      <th scope="col">操作</th>
+      <th scope="col" class="theme-table__col-actions">
+        <span class="theme-table__col-actions-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="5" cy="12" r="1.8"></circle>
+            <circle cx="12" cy="12" r="1.8"></circle>
+            <circle cx="19" cy="12" r="1.8"></circle>
+          </svg>
+        </span>
+        <span class="sr-only">操作</span>
+      </th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/templates/admin/partials/user_table.html
+++ b/backend/app/templates/admin/partials/user_table.html
@@ -6,7 +6,16 @@
       <th scope="col">邮箱</th>
       <th scope="col">权限</th>
       <th scope="col">创建时间</th>
-      <th scope="col">操作</th>
+      <th scope="col" class="theme-table__col-actions">
+        <span class="theme-table__col-actions-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="5" cy="12" r="1.8"></circle>
+            <circle cx="12" cy="12" r="1.8"></circle>
+            <circle cx="19" cy="12" r="1.8"></circle>
+          </svg>
+        </span>
+        <span class="sr-only">操作</span>
+      </th>
     </tr>
   </thead>
   <tbody>

--- a/backend/app/templates/admin/password.html
+++ b/backend/app/templates/admin/password.html
@@ -59,7 +59,7 @@
                   />
                 </div>
               </div>
-              <div class="theme-form__footer theme-form__footer--center">
+              <div class="theme-form__footer theme-form__footer--center theme-form__footer--balanced">
                 <button type="submit" class="theme-button theme-button--solid">
                   更新密码
                 </button>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -383,6 +383,12 @@
         line-height: 0;
       }
 
+      @media (min-width: 1024px) {
+        .theme-hero__brand {
+          padding: 0.45rem 2.8rem;
+        }
+      }
+
       .theme-hero__heading {
         display: flex;
         flex-direction: column;
@@ -1140,6 +1146,11 @@
         justify-content: center;
       }
 
+      .theme-form__footer--balanced {
+        justify-content: center;
+        gap: 0.85rem;
+      }
+
       .theme-button {
         display: inline-flex;
         align-items: center;
@@ -1198,6 +1209,22 @@
       .theme-button--sm {
         padding: 0.45rem 1rem;
         font-size: 0.82rem;
+      }
+
+      .theme-button--icon {
+        padding: 0;
+        width: 2.75rem;
+        height: 2.75rem;
+        border-radius: 999px;
+        flex: 0 0 auto;
+      }
+
+      .theme-button--icon svg {
+        width: 1.35rem;
+        height: 1.35rem;
+        stroke: currentColor;
+        stroke-width: 1.8;
+        fill: none;
       }
 
       .theme-feedback {
@@ -1297,6 +1324,29 @@
 
       .theme-table__cell--right {
         text-align: right;
+      }
+
+      .theme-table__col-actions {
+        text-align: right;
+        width: 0;
+        white-space: nowrap;
+      }
+
+      .theme-table__col-actions-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-end;
+        width: 1.75rem;
+        height: 1.75rem;
+        color: var(--theme-muted);
+      }
+
+      .theme-table__col-actions-icon svg {
+        width: 1.1rem;
+        height: 1.1rem;
+        stroke: currentColor;
+        stroke-width: 1.8;
+        fill: none;
       }
 
       .theme-table__actions {
@@ -1601,6 +1651,10 @@
           justify-content: center;
         }
 
+        .theme-hero__actions .theme-button--icon {
+          width: 3rem;
+        }
+
         .theme-main {
           padding: 0 1.5rem 2rem;
         }
@@ -1829,6 +1883,40 @@
           width: 100%;
         }
 
+        .theme-button--icon {
+          width: 3rem;
+          height: 3rem;
+        }
+
+        .theme-button--icon svg {
+          width: 1.35rem;
+          height: 1.35rem;
+        }
+
+        .theme-field,
+        .theme-field.theme-form__span-full,
+        .theme-field--constrained {
+          width: 100%;
+          max-width: 100%;
+        }
+
+        .theme-card__body .theme-input,
+        .theme-card__body .theme-input--wide,
+        .theme-card__body .theme-input-affix,
+        .theme-card__body .theme-input-affix__input,
+        .theme-card__body .theme-select {
+          width: 100%;
+          max-width: 100%;
+        }
+
+        .theme-form__footer--balanced {
+          align-items: center;
+        }
+
+        .theme-form__footer--balanced .theme-button {
+          width: min(100%, 16rem);
+        }
+
         .theme-hero__actions .theme-button,
         .theme-form__actions .theme-button,
         .theme-table__details-actions .theme-button {
@@ -1967,17 +2055,42 @@
                 </div>
                 {% if show_logout_button %}
                 <a
-                  class="theme-button theme-button--ghost theme-button--password"
+                  class="theme-button theme-button--ghost theme-button--icon theme-button--password"
                   href="/admin/password"
+                  aria-label="修改密码"
                 >
-                  改密
+                  <svg
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    fill="none"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="8" cy="12" r="3"></circle>
+                    <path d="M11 12h9"></path>
+                    <path d="M18 9v6"></path>
+                    <path d="M20 11v2"></path>
+                  </svg>
+                  <span class="sr-only">改密</span>
                 </a>
                 <a
-                  class="theme-button theme-button--ghost theme-button--logout"
+                  class="theme-button theme-button--ghost theme-button--icon theme-button--logout"
                   href="/admin/logout"
+                  aria-label="退出登录"
                   onclick="return confirm('确认退出登录？')"
                 >
-                  退出
+                  <svg
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    fill="none"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M15 5h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-3"></path>
+                    <path d="M10 17l5-5-5-5"></path>
+                    <path d="M15 12H3"></path>
+                  </svg>
+                  <span class="sr-only">退出</span>
                 </a>
                 {% endif %}
               </div>


### PR DESCRIPTION
## Summary
- tighten mobile form fields and password page controls so inputs and buttons stay within their cards
- convert header and table operation controls to compact icon buttons and extend the desktop logo badge
- ensure the mobile action menu opens reliably by syncing the details toggle state

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e4c423c3e8832f98b8bb5f444699c6