### PR TITLE
Adjust admin interface layouts for desktop and mobile

### DIFF
--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -909,6 +909,11 @@
 
     details.classList.toggle("is-open", Boolean(isOpen));
 
+    const row = details.closest(".theme-table__row");
+    if (row instanceof HTMLElement) {
+      row.classList.toggle("is-details-open", Boolean(isOpen));
+    }
+
     if (summary instanceof HTMLElement) {
       summary.setAttribute("aria-expanded", isOpen ? "true" : "false");
     }

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -3,7 +3,7 @@
   class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="theme-table__cell">
+  <td class="theme-table__cell theme-table__cell--summary">
     <button
       type="button"
       class="theme-copy"
@@ -32,7 +32,7 @@
     {{ item.owner_username or '—' }}
   </td>
   {% endif %}
-  <td class="theme-table__cell theme-table__cell--right">
+  <td class="theme-table__cell theme-table__cell--right theme-table__cell--actions">
     <div class="theme-table__actions theme-table__actions--desktop">
       <button
         type="button"
@@ -65,6 +65,29 @@
         <span class="sr-only">展开操作菜单</span>
       </summary>
       <div class="theme-table__details-panel">
+        <div class="theme-table__details-summary">
+          <span class="theme-table__details-title">短链</span>
+          <div class="theme-table__details-primary">
+            <button
+              type="button"
+              class="theme-copy"
+              data-copy-value="{{ short_link_prefix }}{{ item.code }}"
+              aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
+            >
+              <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
+              <span class="theme-copy__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+                  <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+                </svg>
+              </span>
+              <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
+            </button>
+          </div>
+          {% if show_user_column %}
+          <span class="theme-table__details-meta">用户：{{ item.owner_username or '—' }}</span>
+          {% endif %}
+        </div>
         <dl class="theme-table__details-list">
           <div class="theme-table__details-item">
             <dt>目标地址</dt>

--- a/backend/app/templates/admin/partials/link_table.html
+++ b/backend/app/templates/admin/partials/link_table.html
@@ -12,13 +12,6 @@
       <th scope="col" class="theme-table__col-actions">
         <span class="theme-table__col-actions-label">
           <span class="theme-table__col-actions-text">操作</span>
-          <span class="theme-table__col-actions-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="5" cy="12" r="1.8"></circle>
-              <circle cx="12" cy="12" r="1.8"></circle>
-              <circle cx="19" cy="12" r="1.8"></circle>
-            </svg>
-          </span>
         </span>
       </th>
     </tr>

--- a/backend/app/templates/admin/partials/settings_card.html
+++ b/backend/app/templates/admin/partials/settings_card.html
@@ -2,8 +2,7 @@
   <div class="theme-card__header">
     <h2 class="theme-card__title">站点设置</h2>
     <p class="theme-card__subtitle">
-      配置基础域名、短链生成规则与品牌资源。短链示例：
-      <code class="font-mono">{{ short_link_example }}</code>
+      配置基础域名、短链生成规则与品牌资源。
     </p>
   </div>
   <div class="theme-card__body">

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -3,7 +3,7 @@
   class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="theme-table__cell">
+  <td class="theme-table__cell theme-table__cell--summary">
     <button
       type="button"
       class="theme-copy"
@@ -31,7 +31,7 @@
   {% if show_user_column %}
   <td class="theme-table__cell theme-table__cell--muted">{{ item.owner_username or '—' }}</td>
   {% endif %}
-  <td class="theme-table__cell theme-table__cell--right">
+  <td class="theme-table__cell theme-table__cell--right theme-table__cell--actions">
     <div class="theme-table__actions theme-table__actions--desktop">
       <button
         type="button"
@@ -64,6 +64,29 @@
         <span class="sr-only">展开操作菜单</span>
       </summary>
       <div class="theme-table__details-panel">
+        <div class="theme-table__details-summary">
+          <span class="theme-table__details-title">子域</span>
+          <div class="theme-table__details-primary">
+            <button
+              type="button"
+              class="theme-copy"
+              data-copy-value="https://{{ item.host }}"
+              aria-label="复制子域 https://{{ item.host }}"
+            >
+              <span class="theme-copy__text">{{ item.host }}</span>
+              <span class="theme-copy__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+                  <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+                </svg>
+              </span>
+              <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
+            </button>
+          </div>
+          {% if show_user_column %}
+          <span class="theme-table__details-meta">用户：{{ item.owner_username or '—' }}</span>
+          {% endif %}
+        </div>
         <dl class="theme-table__details-list">
           <div class="theme-table__details-item">
             <dt>目标地址</dt>

--- a/backend/app/templates/admin/partials/subdomain_table.html
+++ b/backend/app/templates/admin/partials/subdomain_table.html
@@ -13,13 +13,6 @@
       <th scope="col" class="theme-table__col-actions">
         <span class="theme-table__col-actions-label">
           <span class="theme-table__col-actions-text">操作</span>
-          <span class="theme-table__col-actions-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="5" cy="12" r="1.8"></circle>
-              <circle cx="12" cy="12" r="1.8"></circle>
-              <circle cx="19" cy="12" r="1.8"></circle>
-            </svg>
-          </span>
         </span>
       </th>
     </tr>

--- a/backend/app/templates/admin/partials/user_row.html
+++ b/backend/app/templates/admin/partials/user_row.html
@@ -3,7 +3,7 @@
   class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
-  <td class="theme-table__cell theme-table__cell--wrap">
+  <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--summary">
     {{ item.username }}
   </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.email }}</td>
@@ -17,7 +17,7 @@
   <td class="theme-table__cell theme-table__cell--muted">
     {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
   </td>
-  <td class="theme-table__cell theme-table__cell--right">
+  <td class="theme-table__cell theme-table__cell--right theme-table__cell--actions">
     <div class="theme-table__actions theme-table__actions--desktop">
       <button
         type="button"
@@ -50,6 +50,12 @@
         <span class="sr-only">展开操作菜单</span>
       </summary>
       <div class="theme-table__details-panel">
+        <div class="theme-table__details-summary">
+          <span class="theme-table__details-title">用户名</span>
+          <div class="theme-table__details-primary">
+            <span class="theme-table__details-meta">{{ item.username }}</span>
+          </div>
+        </div>
         <dl class="theme-table__details-list">
           <div class="theme-table__details-item">
             <dt>邮箱</dt>

--- a/backend/app/templates/admin/partials/user_table.html
+++ b/backend/app/templates/admin/partials/user_table.html
@@ -9,13 +9,6 @@
       <th scope="col" class="theme-table__col-actions">
         <span class="theme-table__col-actions-label">
           <span class="theme-table__col-actions-text">操作</span>
-          <span class="theme-table__col-actions-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="5" cy="12" r="1.8"></circle>
-              <circle cx="12" cy="12" r="1.8"></circle>
-              <circle cx="19" cy="12" r="1.8"></circle>
-            </svg>
-          </span>
         </span>
       </th>
     </tr>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -95,6 +95,12 @@
         --theme-copy-feedback: rgba(79, 70, 229, 0.95);
       }
 
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
       html,
       body {
         min-height: 100%;
@@ -872,8 +878,10 @@
       }
 
       .theme-form--login .theme-button--block {
-        max-width: none;
-        width: 100%;
+        width: min(100%, 10.5rem);
+        max-width: 10.5rem;
+        margin-left: auto;
+        margin-right: auto;
       }
 
       .theme-card--auth .theme-card__header {
@@ -1155,6 +1163,10 @@
         gap: 0.85rem;
       }
 
+      .theme-form__footer--balanced .theme-button {
+        width: min(100%, 11rem);
+      }
+
       .theme-button {
         display: inline-flex;
         align-items: center;
@@ -1364,8 +1376,8 @@
 
       .theme-table__col-actions {
         text-align: right;
-        width: 9.5rem;
-        min-width: 9.5rem;
+        width: 8.5rem;
+        min-width: 8.5rem;
         white-space: nowrap;
       }
 
@@ -1385,20 +1397,48 @@
       }
 
       .theme-table__col-actions-icon {
-        display: inline-flex;
-        align-items: center;
-        justify-content: flex-end;
-        width: 1.75rem;
-        height: 1.75rem;
+        display: none;
+      }
+
+      .theme-table__cell--summary {
+        position: relative;
+      }
+
+      .theme-table__cell--actions {
+        position: relative;
+      }
+
+      .theme-table__details-summary {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        padding-bottom: 0.65rem;
+        border-bottom: 1px solid var(--theme-surface-border);
+      }
+
+      .theme-table__details-summary:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+      }
+
+      .theme-table__details-title {
+        font-size: 0.78rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
         color: var(--theme-muted);
       }
 
-      .theme-table__col-actions-icon svg {
-        width: 1.1rem;
-        height: 1.1rem;
-        stroke: currentColor;
-        stroke-width: 1.8;
-        fill: none;
+      .theme-table__details-primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        flex-wrap: wrap;
+      }
+
+      .theme-table__details-meta {
+        font-size: 0.85rem;
+        color: var(--theme-text-secondary);
       }
 
       .theme-table__actions {
@@ -1699,12 +1739,8 @@
         }
 
         .theme-hero__actions .theme-button {
-          width: 100%;
+          width: auto;
           justify-content: center;
-        }
-
-        .theme-hero__actions .theme-button--icon {
-          width: 3rem;
         }
 
         .theme-main {
@@ -1923,11 +1959,11 @@
         }
 
         .theme-table__col-actions-label {
-          justify-content: flex-start;
+          justify-content: flex-end;
         }
 
         .theme-table__cell--right {
-          text-align: left;
+          text-align: right;
         }
 
         .theme-table__details {
@@ -1942,6 +1978,15 @@
         .theme-table__details-panel {
           margin-top: 0.65rem;
           margin-left: 0;
+        }
+
+        .theme-table__row.is-details-open .theme-table__cell--summary,
+        .theme-table__row.is-details-open .theme-table__cell--actions {
+          display: none;
+        }
+
+        .theme-table__row.is-details-open .theme-table__details-panel {
+          margin-top: 0;
         }
 
         .theme-login-feedback {
@@ -2007,7 +2052,7 @@
         }
 
         .theme-form__footer--balanced .theme-button {
-          width: min(100%, 14rem);
+          width: min(100%, 11rem);
           margin-left: auto;
           margin-right: auto;
         }


### PR DESCRIPTION
## Summary
- shorten the desktop login button and align the operations column header without the ellipsis icon
- show key record information inside the mobile details card, hiding the row when expanded, and tweak hero action buttons
- apply box-sizing fixes to keep form inputs inside their containers and remove the settings short link example text

## Testing
- pytest backend

------
https://chatgpt.com/codex/tasks/task_b_68e4ddc75b80832f9926f09876679b77