### PR TITLE
Adjust action layout for short link entries

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1376,8 +1376,8 @@
 
       .theme-table__col-actions {
         text-align: left;
-        width: 9.5rem;
-        min-width: 9.5rem;
+        width: clamp(8.5rem, 17vw, 11rem);
+        min-width: clamp(8.5rem, 17vw, 11rem);
         white-space: nowrap;
       }
 
@@ -1445,12 +1445,18 @@
         padding-left: 1rem;
         padding-right: 1rem;
         text-align: left;
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.65rem;
       }
 
       .theme-table__actions {
         display: flex;
-        justify-content: flex-start;
+        justify-content: flex-end;
+        align-items: center;
         gap: 0.5rem;
+        flex-wrap: nowrap;
       }
 
       .theme-table__actions .theme-button {
@@ -1468,7 +1474,7 @@
 
       .theme-table__details {
         display: none;
-        margin-left: auto;
+        flex-shrink: 0;
       }
 
       .theme-table__details-toggle {
@@ -1521,7 +1527,8 @@
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
-        min-width: min(100%, 18rem);
+        min-width: min(100%, 22rem);
+        max-width: min(100%, 26rem);
         text-align: left;
       }
 


### PR DESCRIPTION
## Summary
- widen the short link details panel to better utilize the available horizontal space
- align the action buttons and overflow toggle on the same row by using a flex layout and responsive column widths

## Testing
- not run (frontend styling change)


------
https://chatgpt.com/codex/tasks/task_b_68e506cd6d38832f8602b08155150103