### PR TITLE
Fix admin table rows from wrapping on desktop

### DIFF
--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -9,6 +9,7 @@
       class="theme-copy"
       data-copy-value="{{ short_link_prefix }}{{ item.code }}"
       aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
+      title="{{ short_link_prefix }}{{ item.code }}"
     >
       <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
       <span class="theme-copy__icon" aria-hidden="true">
@@ -21,7 +22,7 @@
     </button>
   </td>
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted theme-table__col-target">
-    <span class="theme-table__target-text">{{ item.target_url }}</span>
+    <span class="theme-table__target-text" title="{{ item.target_url }}">{{ item.target_url }}</span>
   </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>
   <td class="theme-table__cell theme-table__cell--muted">

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -9,6 +9,7 @@
       class="theme-copy"
       data-copy-value="https://{{ item.host }}"
       aria-label="复制子域 https://{{ item.host }}"
+      title="https://{{ item.host }}"
     >
       <span class="theme-copy__text">{{ item.host }}</span>
       <span class="theme-copy__icon" aria-hidden="true">
@@ -21,7 +22,7 @@
     </button>
   </td>
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted theme-table__col-target">
-    <span class="theme-table__target-text">{{ item.target_url }}</span>
+    <span class="theme-table__target-text" title="{{ item.target_url }}">{{ item.target_url }}</span>
   </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.code }}</td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.hits }}</td>

--- a/backend/app/templates/admin/partials/user_row.html
+++ b/backend/app/templates/admin/partials/user_row.html
@@ -4,7 +4,9 @@
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--summary">
-    {{ item.username }}
+    <span class="theme-table__summary-text" title="{{ item.username }}">
+      {{ item.username }}
+    </span>
   </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.email }}</td>
   <td class="theme-table__cell">

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1323,13 +1323,46 @@
 
       .theme-table__col-target {
         width: clamp(11rem, 24vw, 18rem);
+        min-width: clamp(11rem, 24vw, 18rem);
+      }
+
+      .theme-table__cell--summary {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+
+      .theme-table__cell--summary .theme-copy {
+        min-width: 0;
+        max-width: 100%;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+      }
+
+      .theme-table__summary-text,
+      .theme-table__cell--summary .theme-copy__text {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .theme-table__summary-text {
+        flex: 1 1 auto;
+        min-width: 0;
       }
 
       .theme-table__target-text {
-        display: inline-block;
+        display: block;
         max-width: clamp(11rem, 24vw, 18rem);
-        word-break: break-all;
-        white-space: normal;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       .theme-table tbody tr {
@@ -1367,7 +1400,7 @@
       }
 
       .theme-table__cell--wrap {
-        word-break: break-all;
+        overflow: hidden;
       }
 
       .theme-table__cell--right {
@@ -1398,21 +1431,6 @@
 
       .theme-table__col-actions-icon {
         display: none;
-      }
-
-      .theme-table__cell--summary {
-        position: relative;
-        display: flex;
-        align-items: center;
-        min-width: 0;
-      }
-
-      .theme-table__cell--summary .theme-copy {
-        min-width: 0;
-      }
-
-      .theme-table__cell--summary .theme-copy__text {
-        overflow-wrap: anywhere;
       }
 
       .theme-table__cell--actions {
@@ -1739,6 +1757,21 @@
         .theme-table__target-text {
           width: clamp(10rem, 42vw, 18rem);
           max-width: clamp(10rem, 42vw, 18rem);
+        }
+
+        .theme-table__cell--summary {
+          white-space: normal;
+        }
+
+        .theme-table__summary-text,
+        .theme-table__cell--summary .theme-copy__text,
+        .theme-table__target-text {
+          white-space: normal;
+          overflow-wrap: anywhere;
+        }
+
+        .theme-table__target-text {
+          text-overflow: clip;
         }
       }
 


### PR DESCRIPTION
## Summary
- keep admin table summary and target columns on a single line with ellipsis and responsive fallbacks
- add hover titles so truncated hosts, short links, and target URLs remain accessible
- update user rows to use the shared summary text styling for consistent truncation

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68e5229d61a4832f9dce9e08063c6e15