### PR TITLE
Fix admin table summary column alignment

### DIFF
--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -4,22 +4,24 @@
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
   <td class="theme-table__cell theme-table__cell--summary">
-    <button
-      type="button"
-      class="theme-copy"
-      data-copy-value="{{ short_link_prefix }}{{ item.code }}"
-      aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
-      title="{{ short_link_prefix }}{{ item.code }}"
-    >
-      <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
-      <span class="theme-copy__icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24">
-          <rect x="9" y="9" width="12" height="12" rx="2"></rect>
-          <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
-        </svg>
-      </span>
-      <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
-    </button>
+    <div class="theme-table__summary">
+      <button
+        type="button"
+        class="theme-copy"
+        data-copy-value="{{ short_link_prefix }}{{ item.code }}"
+        aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
+        title="{{ short_link_prefix }}{{ item.code }}"
+      >
+        <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
+        <span class="theme-copy__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+            <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+          </svg>
+        </span>
+        <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
+      </button>
+    </div>
   </td>
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted theme-table__col-target">
     <span class="theme-table__target-text" title="{{ item.target_url }}">{{ item.target_url }}</span>

--- a/backend/app/templates/admin/partials/subdomain_row.html
+++ b/backend/app/templates/admin/partials/subdomain_row.html
@@ -4,22 +4,24 @@
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
   <td class="theme-table__cell theme-table__cell--summary">
-    <button
-      type="button"
-      class="theme-copy"
-      data-copy-value="https://{{ item.host }}"
-      aria-label="复制子域 https://{{ item.host }}"
-      title="https://{{ item.host }}"
-    >
-      <span class="theme-copy__text">{{ item.host }}</span>
-      <span class="theme-copy__icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24">
-          <rect x="9" y="9" width="12" height="12" rx="2"></rect>
-          <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
-        </svg>
-      </span>
-      <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
-    </button>
+    <div class="theme-table__summary">
+      <button
+        type="button"
+        class="theme-copy"
+        data-copy-value="https://{{ item.host }}"
+        aria-label="复制子域 https://{{ item.host }}"
+        title="https://{{ item.host }}"
+      >
+        <span class="theme-copy__text">{{ item.host }}</span>
+        <span class="theme-copy__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <rect x="9" y="9" width="12" height="12" rx="2"></rect>
+            <path d="M5 15V5a2 2 0 0 1 2-2h10"></path>
+          </svg>
+        </span>
+        <span class="theme-copy__feedback" aria-hidden="true">已复制</span>
+      </button>
+    </div>
   </td>
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--muted theme-table__col-target">
     <span class="theme-table__target-text" title="{{ item.target_url }}">{{ item.target_url }}</span>

--- a/backend/app/templates/admin/partials/user_row.html
+++ b/backend/app/templates/admin/partials/user_row.html
@@ -4,9 +4,11 @@
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
   <td class="theme-table__cell theme-table__cell--wrap theme-table__cell--summary">
-    <span class="theme-table__summary-text" title="{{ item.username }}">
-      {{ item.username }}
-    </span>
+    <div class="theme-table__summary">
+      <span class="theme-table__summary-text" title="{{ item.username }}">
+        {{ item.username }}
+      </span>
+    </div>
   </td>
   <td class="theme-table__cell theme-table__cell--muted">{{ item.email }}</td>
   <td class="theme-table__cell">

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1328,15 +1328,20 @@
 
       .theme-table__cell--summary {
         position: relative;
+        min-width: 0;
+      }
+
+      .theme-table__summary {
         display: flex;
         align-items: center;
         gap: 0.5rem;
         min-width: 0;
+        width: 100%;
         white-space: nowrap;
         overflow: hidden;
       }
 
-      .theme-table__cell--summary .theme-copy {
+      .theme-table__summary .theme-copy {
         min-width: 0;
         max-width: 100%;
         display: inline-flex;
@@ -1345,7 +1350,7 @@
       }
 
       .theme-table__summary-text,
-      .theme-table__cell--summary .theme-copy__text {
+      .theme-table__summary .theme-copy__text {
         display: block;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -1759,12 +1764,12 @@
           max-width: clamp(10rem, 42vw, 18rem);
         }
 
-        .theme-table__cell--summary {
+        .theme-table__summary {
           white-space: normal;
         }
 
         .theme-table__summary-text,
-        .theme-table__cell--summary .theme-copy__text,
+        .theme-table__summary .theme-copy__text,
         .theme-table__target-text {
           white-space: normal;
           overflow-wrap: anywhere;


### PR DESCRIPTION
## Summary
- wrap the first column content for short links, subdomains, and users in a shared summary container so table rows render consistently
- adjust shared styles to keep summary cells full-width while preserving ellipsis and responsive behavior

## Testing
- pytest backend/tests/test_short_links.py

------
https://chatgpt.com/codex/tasks/task_b_68e5268f504c832faf168518230b3c6c