### PR TITLE
Fix mobile list separator alignment

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -2097,6 +2097,13 @@
           grid-auto-rows: auto;
           align-items: center;
           column-gap: 0.5rem;
+          border-top: 1px solid rgba(148, 163, 184, 0.15);
+        }
+
+        .theme-table tbody
+          tr.theme-table__row:not(.theme-table__row--editing)
+          > .theme-table__cell {
+          border-top: none;
         }
 
         .theme-table tbody


### PR DESCRIPTION
## Summary
- add a row-level border for mobile tables so the content and action columns share the same separator
- remove per-cell borders on mobile layouts to eliminate misaligned horizontal lines

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e53a97dfa0832fb76d79d138905d74