### PR TITLE
Center admin login card on desktop screens

### DIFF
--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -1,9 +1,26 @@
 {% extends "base.html" %}
 
 {% block content %}
+<style>
+  @media (min-width: 1024px) {
+    .theme-shell__body--auth {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      min-height: clamp(24rem, 60vh, 32rem);
+    }
+  }
+
+  @media (min-width: 1536px) {
+    .theme-shell__body--auth {
+      min-height: clamp(26rem, 58vh, 36rem);
+    }
+  }
+</style>
 <div class="theme-layout">
   <section class="theme-shell">
-    <div class="theme-shell__body theme-shell__body--center">
+    <div class="theme-shell__body theme-shell__body--center theme-shell__body--auth">
       <section class="theme-card theme-card--narrow theme-card--auth">
         <div class="theme-card__header theme-card__header--center">
           <h2 class="theme-card__title">登录 {{ site_settings.site_domain }} 管理后台</h2>


### PR DESCRIPTION
## Summary
- add a desktop-only style override for the admin login shell to center the card
- mark the login shell body with a dedicated class so the responsive centering only affects that page

## Testing
- uvicorn backend.app.main:app --host 0.0.0.0 --port 8000


------
https://chatgpt.com/codex/tasks/task_b_68e53eb04060832f8ba8d3b778a156d4