### PR TITLE
Update short link prefix hint text

### DIFF
--- a/backend/app/templates/admin/partials/settings_card.html
+++ b/backend/app/templates/admin/partials/settings_card.html
@@ -57,7 +57,7 @@
             placeholder="如 / 或 /r/"
             value="{{ site_settings.short_link_path }}"
           />
-          <p class="theme-hint">访问短链时的路径前缀，例如 /r/ 将生成 {{ short_link_prefix }}code。</p>
+          <p class="theme-hint">访问短链时的路径前缀，例如 /r/ 将生成 https://yet.la/r/code。</p>
         </div>
         <div class="theme-field theme-form__span-full theme-field--mobile-condensed">
           <label for="logo_url" class="theme-label">Logo 图片地址 *</label>


### PR DESCRIPTION
## Summary
- correct the settings page hint to show the full example short link https://yet.la/r/code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e542aefe88832f9f2c15451103458f