### PR TITLE
Adjust short link prefix hint example

### DIFF
--- a/backend/app/templates/admin/partials/settings_card.html
+++ b/backend/app/templates/admin/partials/settings_card.html
@@ -57,7 +57,7 @@
             placeholder="如 / 或 /r/"
             value="{{ site_settings.short_link_path }}"
           />
-          <p class="theme-hint">访问短链时的路径前缀，例如 /r/ 将生成 {{ short_link_prefix }}code。</p>
+          <p class="theme-hint">访问短链时的路径前缀，例如 /r/ 将生成 {{ short_link_prefix }}r/code。</p>
         </div>
         <div class="theme-field theme-form__span-full theme-field--mobile-condensed">
           <label for="logo_url" class="theme-label">Logo 图片地址 *</label>


### PR DESCRIPTION
## Summary
- update the settings form hint to clarify the generated path example for short links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e544e6ce94832f842f4f084c473439