### PR TITLE
Add slug validation and subdomain blacklist management

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from .models import (
     Base,
     ShortLink,
     SiteSettings,
+    SubdomainBlacklist,
     SubdomainRedirect,
     User,
     ensure_subdomain_hits_column,
@@ -39,6 +40,8 @@ from .schemas import (
     ShortLinkUpdate,
     SiteSettings as SiteSettingsSchema,
     SiteSettingsUpdate,
+    SubdomainBlacklist as SubdomainBlacklistSchema,
+    SubdomainBlacklistCreate,
     SubdomainRedirect as SubdomainRedirectSchema,
     SubdomainRedirectCreate,
     SubdomainRedirectUpdate,
@@ -59,8 +62,23 @@ from .settings_service import (
     resolve_short_link_hosts,
     update_site_settings,
 )
+from .validators import extract_subdomain_label
 
 MAX_CODE_ATTEMPTS = 10
+
+_FEEDBACK_TONES = {
+    "success": "theme-feedback__message--success",
+    "info": "theme-feedback__message--info",
+    "warning": "theme-feedback__message--warning",
+    "error": "theme-feedback__message--error",
+}
+
+
+def _feedback_html(message: str, *, tone: str = "info") -> str:
+    """Render a styled feedback snippet for HTMX responses."""
+
+    tone_class = _FEEDBACK_TONES.get(tone, _FEEDBACK_TONES["info"])
+    return f'<div class="theme-feedback__message {tone_class}">{message}</div>'
 
 app = FastAPI(
     title="Yetla Redirect API",
@@ -110,32 +128,20 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
     if exc.status_code in {status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT}:
         if hx_request:
             return HTMLResponse(
-                (
-                    "<div class=\"rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700\">"
-                    f"{exc.detail}"
-                    "</div>"
-                ),
+                _feedback_html(str(exc.detail), tone="error"),
                 status_code=exc.status_code,
                 headers=headers,
             )
         return JSONResponse({"error": exc.detail}, status_code=exc.status_code, headers=headers)
     if exc.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY and hx_request:
         return HTMLResponse(
-            (
-                "<div class=\"rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700\">"
-                f"{_format_validation_errors(exc.detail)}"
-                "</div>"
-            ),
+            _feedback_html(_format_validation_errors(exc.detail), tone="error"),
             status_code=exc.status_code,
             headers=headers,
         )
     if hx_request:
         return HTMLResponse(
-            (
-                "<div class=\"rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700\">"
-                f"{exc.detail}"
-                "</div>"
-            ),
+            _feedback_html(str(exc.detail), tone="error"),
             status_code=exc.status_code,
             headers=headers,
         )
@@ -145,7 +151,7 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 def _generate_unique_code(db: Session, length: int) -> str:
     """生成唯一的短链接 code。"""
 
-    alphabet = string.ascii_letters + string.digits
+    alphabet = string.ascii_lowercase + string.digits
     for _ in range(MAX_CODE_ATTEMPTS):
         candidate = "".join(secrets.choice(alphabet) for _ in range(length))
         exists = db.scalar(select(ShortLink).where(ShortLink.code == candidate))
@@ -225,6 +231,15 @@ def _ensure_subdomain_permission(redirect: SubdomainRedirect, user: User) -> Non
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="无权操作该子域")
 
 
+def _ensure_subdomain_not_blacklisted(db: Session, host: str) -> None:
+    label = extract_subdomain_label(host)
+    if not label:
+        return
+    exists = db.scalar(select(SubdomainBlacklist).where(SubdomainBlacklist.label == label))
+    if exists:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="子域前缀已在黑名单中")
+
+
 async def _parse_short_link_payload(request: Request) -> ShortLinkCreate:
     """解析短链请求载荷，兼容 JSON 与表单提交。"""
 
@@ -238,7 +253,10 @@ async def _parse_short_link_payload(request: Request) -> ShortLinkCreate:
     try:
         return ShortLinkCreate.model_validate(data)
     except ValidationError as exc:  # pragma: no cover - FastAPI 将统一处理
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 async def _parse_short_link_update_payload(request: Request) -> ShortLinkUpdate:
@@ -254,7 +272,10 @@ async def _parse_short_link_update_payload(request: Request) -> ShortLinkUpdate:
     try:
         return ShortLinkUpdate.model_validate(data)
     except ValidationError as exc:  # pragma: no cover - FastAPI 将统一处理
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 async def _parse_subdomain_payload(request: Request) -> SubdomainRedirectCreate:
@@ -270,7 +291,10 @@ async def _parse_subdomain_payload(request: Request) -> SubdomainRedirectCreate:
     try:
         return SubdomainRedirectCreate.model_validate(data)
     except ValidationError as exc:  # pragma: no cover - FastAPI 将统一处理
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 async def _parse_subdomain_update_payload(
@@ -288,7 +312,30 @@ async def _parse_subdomain_update_payload(
     try:
         return SubdomainRedirectUpdate.model_validate(data)
     except ValidationError as exc:  # pragma: no cover - FastAPI 将统一处理
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
+
+
+async def _parse_subdomain_blacklist_payload(
+    request: Request,
+) -> SubdomainBlacklistCreate:
+    """解析子域黑名单表单或 JSON 载荷。"""
+
+    content_type = request.headers.get("content-type", "").lower()
+    if content_type.startswith("application/json"):
+        data = await request.json()
+    else:
+        data = await _read_form_data(request, content_type)
+
+    try:
+        return SubdomainBlacklistCreate.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - FastAPI 统一处理
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 def _parse_boolean(value: str | None) -> bool:
@@ -318,7 +365,10 @@ async def _parse_user_create_payload(request: Request) -> UserCreate:
     try:
         return UserCreate.model_validate(data)
     except ValidationError as exc:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 async def _parse_user_update_payload(request: Request) -> UserUpdate:
@@ -344,7 +394,10 @@ async def _parse_user_update_payload(request: Request) -> UserUpdate:
     try:
         return UserUpdate.model_validate(data)
     except ValidationError as exc:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 async def _parse_password_change_payload(request: Request) -> PasswordChange:
@@ -358,7 +411,10 @@ async def _parse_password_change_payload(request: Request) -> PasswordChange:
     try:
         return PasswordChange.model_validate(data)
     except ValidationError as exc:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 async def _parse_site_settings_payload(request: Request) -> SiteSettingsUpdate:
@@ -372,7 +428,10 @@ async def _parse_site_settings_payload(request: Request) -> SiteSettingsUpdate:
     try:
         return SiteSettingsUpdate.model_validate(data)
     except ValidationError as exc:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()) from exc
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
 
 
 def _format_validation_errors(detail: Any) -> str:
@@ -397,6 +456,28 @@ def _format_validation_errors(detail: Any) -> str:
         if messages:
             return "；".join(messages)
     return str(detail)
+
+
+def _serialize_validation_detail(detail: Any) -> Any:
+    """Ensure validation errors are JSON serializable for API responses."""
+
+    if not isinstance(detail, list):
+        return detail
+    serialized: list[Any] = []
+    for item in detail:
+        if not isinstance(item, dict):
+            serialized.append(item)
+            continue
+        converted = item.copy()
+        ctx = converted.get("ctx")
+        if isinstance(ctx, dict):
+            converted_ctx = {
+                key: (str(value) if isinstance(value, Exception) else value)
+                for key, value in ctx.items()
+            }
+            converted["ctx"] = converted_ctx
+        serialized.append(converted)
+    return serialized
 
 
 def _commit_session(db: Session, conflict_detail: str | None = None) -> None:
@@ -459,11 +540,7 @@ async def update_site_settings_endpoint(
     short_link_prefix = build_short_link_prefix(settings)
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        feedback_html = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "站点设置已更新"
-            "</div>"
-        )
+        feedback_html = _feedback_html("站点设置已更新", tone="success")
         template = admin_templates.get_template("admin/partials/settings_card.html")
         content = template.render(
             {
@@ -531,11 +608,9 @@ async def create_short_link(
     db.refresh(short_link)
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "短链创建成功：<code class=\"font-mono\">"
-            f"{short_link.code}"
-            "</code></div>"
+        message = _feedback_html(
+            f"短链创建成功：<code class=\"theme-feedback__code\">{short_link.code}</code>",
+            tone="success",
         )
         return HTMLResponse(
             message,
@@ -564,11 +639,7 @@ def delete_short_link(
     _commit_session(db)
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700\">"
-            "短链已删除"
-            "</div>"
-        )
+        message = _feedback_html("短链已删除", tone="warning")
         return HTMLResponse(
             message,
             status_code=status.HTTP_200_OK,
@@ -609,11 +680,7 @@ async def update_short_link(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "短链已更新"
-            "</div>"
-        )
+        message = _feedback_html("短链已更新", tone="success")
         row_html = admin_templates.get_template("admin/partials/link_row.html").render(
             {"request": request, "item": short_link, "oob": True}
         )
@@ -659,6 +726,7 @@ async def create_subdomain(
     """创建子域跳转规则，Host 为完整域名。"""
 
     host = payload.host
+    _ensure_subdomain_not_blacklisted(db, host)
     existing = db.scalar(select(SubdomainRedirect).where(SubdomainRedirect.host == host))
     if existing:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="子域跳转已存在")
@@ -675,11 +743,7 @@ async def create_subdomain(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "子域跳转已创建"
-            "</div>"
-        )
+        message = _feedback_html("子域跳转已创建", tone="success")
         return HTMLResponse(
             message,
             status_code=status.HTTP_201_CREATED,
@@ -688,6 +752,93 @@ async def create_subdomain(
 
     response.headers["HX-Trigger"] = "refresh-subdomains"
     return redirect
+
+
+@app.get(
+    "/api/subdomain-blacklist",
+    response_model=list[SubdomainBlacklistSchema],
+)
+def list_subdomain_blacklist(
+    _admin: User = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> list[SubdomainBlacklist]:
+    """列出子域黑名单条目。"""
+
+    entries = db.scalars(
+        select(SubdomainBlacklist).order_by(SubdomainBlacklist.label.asc())
+    ).all()
+    return list(entries)
+
+
+@app.post(
+    "/api/subdomain-blacklist",
+    response_model=SubdomainBlacklistSchema,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_subdomain_blacklist_entry(
+    request: Request,
+    response: Response,
+    payload: SubdomainBlacklistCreate = Depends(_parse_subdomain_blacklist_payload),
+    _admin: User = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> SubdomainBlacklist | HTMLResponse:
+    """新增黑名单条目。"""
+
+    existing = db.scalar(
+        select(SubdomainBlacklist).where(SubdomainBlacklist.label == payload.label)
+    )
+    if existing:
+        raise HTTPException(status.HTTP_409_CONFLICT, detail="黑名单条目已存在")
+
+    entry = SubdomainBlacklist(label=payload.label)
+    db.add(entry)
+    _commit_session(db, conflict_detail="黑名单条目已存在")
+    db.refresh(entry)
+
+    hx_request = request.headers.get("hx-request") == "true"
+    if hx_request:
+        message = _feedback_html(
+            f"已加入子域黑名单：<code class=\"theme-feedback__code\">{entry.label}</code>",
+            tone="success",
+        )
+        return HTMLResponse(
+            message,
+            status_code=status.HTTP_201_CREATED,
+            headers={"HX-Trigger": "refresh-subdomain-blacklist"},
+        )
+
+    response.headers["HX-Trigger"] = "refresh-subdomain-blacklist"
+    return entry
+
+
+@app.delete("/api/subdomain-blacklist/{entry_id}")
+def delete_subdomain_blacklist_entry(
+    entry_id: int,
+    request: Request,
+    response: Response,
+    _admin: User = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> Response:
+    """删除黑名单条目。"""
+
+    entry = db.get(SubdomainBlacklist, entry_id)
+    if entry is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="黑名单条目不存在")
+
+    db.delete(entry)
+    _commit_session(db)
+
+    hx_request = request.headers.get("hx-request") == "true"
+    if hx_request:
+        message = _feedback_html("黑名单条目已删除", tone="warning")
+        return HTMLResponse(
+            message,
+            status_code=status.HTTP_200_OK,
+            headers={"HX-Trigger": "refresh-subdomain-blacklist"},
+        )
+
+    response.headers["HX-Trigger"] = "refresh-subdomain-blacklist"
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @app.get(
@@ -734,11 +885,7 @@ async def create_user(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "用户创建成功"
-            "</div>"
-        )
+        message = _feedback_html("用户创建成功", tone="success")
         return HTMLResponse(
             message,
             status_code=status.HTTP_201_CREATED,
@@ -786,11 +933,7 @@ async def update_user(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "用户信息已更新"
-            "</div>"
-        )
+        message = _feedback_html("用户信息已更新", tone="success")
         row_html = admin_templates.get_template("admin/partials/user_row.html").render(
             {"request": request, "item": user, "oob": True}
         )
@@ -834,11 +977,7 @@ def delete_user(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700\">"
-            "用户已删除"
-            "</div>"
-        )
+        message = _feedback_html("用户已删除", tone="warning")
         return HTMLResponse(
             message,
             status_code=status.HTTP_200_OK,
@@ -872,11 +1011,7 @@ async def change_own_password(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "密码修改成功"
-            "</div>"
-        )
+        message = _feedback_html("密码修改成功", tone="success")
         return HTMLResponse(
             message,
             status_code=status.HTTP_200_OK,
@@ -905,11 +1040,7 @@ def delete_subdomain(
     _commit_session(db)
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700\">"
-            "子域跳转已删除"
-            "</div>"
-        )
+        message = _feedback_html("子域跳转已删除", tone="warning")
         return HTMLResponse(
             message,
             status_code=status.HTTP_200_OK,
@@ -941,6 +1072,7 @@ async def update_subdomain(
 
     normalized_host = payload.host
     if normalized_host != redirect.host:
+        _ensure_subdomain_not_blacklisted(db, normalized_host)
         exists = db.scalar(
             select(SubdomainRedirect).where(SubdomainRedirect.host == normalized_host)
         )
@@ -958,11 +1090,7 @@ async def update_subdomain(
 
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
-        message = (
-            "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
-            "子域跳转已更新"
-            "</div>"
-        )
+        message = _feedback_html("子域跳转已更新", tone="success")
         row_html = admin_templates.get_template("admin/partials/subdomain_row.html").render(
             {"request": request, "item": redirect, "oob": True}
         )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -130,6 +130,17 @@ class SubdomainRedirect(Base):
         return self.owner.username if self.owner else None
 
 
+class SubdomainBlacklist(Base):
+    """禁止占用的子域前缀列表。"""
+
+    __tablename__ = "subdomain_blacklist"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    label: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
 class ShortLink(Base):
     """短链接记录表。"""
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -12,6 +12,7 @@ from .settings_service import (
     normalize_short_link_path,
     normalize_site_domain,
 )
+from .validators import normalize_slug
 
 
 class SubdomainRedirectBase(BaseModel):
@@ -22,7 +23,15 @@ class SubdomainRedirectBase(BaseModel):
     @field_validator("host")
     @classmethod
     def _normalize_host(cls, value: str) -> str:
-        return value.strip().lower()
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("子域不能为空")
+        parts = normalized.split(".", 1)
+        prefix = normalize_slug(parts[0], field="子域")
+        if len(parts) == 1:
+            return prefix
+        suffix = parts[1].strip()
+        return f"{prefix}.{suffix}" if suffix else prefix
 
     @field_validator("code")
     @classmethod
@@ -50,6 +59,26 @@ class SubdomainRedirectUpdate(SubdomainRedirectBase):
     pass
 
 
+class SubdomainBlacklistBase(BaseModel):
+    label: str = Field(..., description="子域前缀")
+
+    @field_validator("label")
+    @classmethod
+    def _normalize_label(cls, value: str) -> str:
+        return normalize_slug(value, field="子域")
+
+
+class SubdomainBlacklist(SubdomainBlacklistBase):
+    id: int = Field(..., description="数据库主键")
+    created_at: datetime = Field(..., description="创建时间")
+
+    model_config = {"from_attributes": True}
+
+
+class SubdomainBlacklistCreate(SubdomainBlacklistBase):
+    pass
+
+
 class ShortLinkBase(BaseModel):
     target_url: str = Field(..., description="目标地址")
 
@@ -63,7 +92,9 @@ class ShortLinkCreate(ShortLinkBase):
         if value is None:
             return None
         stripped = value.strip()
-        return stripped or None
+        if not stripped:
+            return None
+        return normalize_slug(stripped, field="短链编码")
 
 
 class ShortLink(ShortLinkBase):
@@ -86,7 +117,7 @@ class ShortLinkUpdate(ShortLinkBase):
         stripped = value.strip()
         if not stripped:
             raise ValueError("短链编码不能为空")
-        return stripped
+        return normalize_slug(stripped, field="短链编码")
 
 
 class UserBase(BaseModel):
@@ -96,10 +127,7 @@ class UserBase(BaseModel):
     @field_validator("username")
     @classmethod
     def _normalize_username(cls, value: str) -> str:
-        normalized = value.strip().lower()
-        if not normalized:
-            raise ValueError("用户名不能为空")
-        return normalized
+        return normalize_slug(value, field="用户名")
 
     @field_validator("email")
     @classmethod

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -98,6 +98,10 @@
                       autocomplete="off"
                       spellcheck="false"
                       placeholder="自动生成，可修改"
+                      pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+                      minlength="3"
+                      maxlength="20"
+                      title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
                     />
                   </div>
                 </div>
@@ -183,6 +187,10 @@
                       autocomplete="off"
                       spellcheck="false"
                       data-domain-input-field
+                      pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+                      minlength="3"
+                      maxlength="20"
+                      title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
                     />
                     <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
                     <input type="hidden" name="host" data-domain-input-hidden />
@@ -239,6 +247,77 @@
             {% include "admin/partials/subdomain_table.html" %}
           </div>
         </section>
+        {% if current_user and current_user.is_admin %}
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">创建子域黑名单</h2>
+            <p class="theme-card__subtitle">
+              添加受限前缀，阻止创建或修改到这些子域名。
+            </p>
+          </div>
+          <div class="theme-card__body">
+            <form
+              class="theme-form"
+              action="/api/subdomain-blacklist"
+              method="post"
+              hx-post="/api/subdomain-blacklist"
+              hx-trigger="submit"
+              hx-target="#subdomain-blacklist-feedback"
+              hx-swap="innerHTML"
+              data-reset-on-success="true"
+              data-success-event="refresh-subdomain-blacklist"
+            >
+              <div class="theme-form__grid theme-form__grid--two">
+                <div class="theme-field theme-form__span-full theme-field--mobile-condensed">
+                  <label for="blacklist-label" class="theme-label">子域前缀 *</label>
+                  <input
+                    id="blacklist-label"
+                    name="label"
+                    type="text"
+                    required
+                    class="theme-input theme-input--wide"
+                    placeholder="如 marketing"
+                    autocomplete="off"
+                    spellcheck="false"
+                    pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+                    minlength="3"
+                    maxlength="20"
+                    title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+                  />
+                </div>
+              </div>
+              <div class="theme-form__footer theme-form__footer--center">
+                <button type="submit" class="theme-button theme-button--solid">
+                  添加黑名单
+                </button>
+              </div>
+            </form>
+          </div>
+          <div
+            id="subdomain-blacklist-feedback"
+            class="theme-feedback"
+            role="status"
+            aria-live="polite"
+          ></div>
+        </section>
+        <section class="theme-card">
+          <div class="theme-card__header">
+            <h2 class="theme-card__title">子域黑名单列表</h2>
+            <p class="theme-card__subtitle">
+              当前受限制的子域前缀，命中将无法创建或修改。
+            </p>
+          </div>
+          <div
+            id="subdomain-blacklist-table"
+            class="theme-card__body theme-card__body--table"
+            hx-get="/admin/subdomains/blacklist/table"
+            hx-trigger="load, refresh-subdomain-blacklist from:body"
+            hx-swap="innerHTML"
+          >
+            {% include "admin/partials/subdomain_blacklist_table.html" %}
+          </div>
+        </section>
+        {% endif %}
       </div>
       {% elif active_tab == 'users' %}
       <div class="theme-stack">
@@ -274,6 +353,10 @@
                       placeholder="如 alice"
                       autocomplete="off"
                       spellcheck="false"
+                      pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+                      minlength="3"
+                      maxlength="20"
+                      title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
                     />
                   </div>
                   <div class="theme-field theme-field--mobile-condensed">

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -46,6 +46,10 @@
                 autocomplete="username"
                 spellcheck="false"
                 value="{{ username_value }}"
+                pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+                minlength="3"
+                maxlength="20"
+                title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
               />
             </div>
             <div class="theme-field">

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -21,6 +21,10 @@
               class="theme-input-affix__input"
               autocomplete="off"
               spellcheck="false"
+              pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+              minlength="3"
+              maxlength="20"
+              title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
             />
           </div>
         </div>

--- a/backend/app/templates/admin/partials/subdomain_blacklist_table.html
+++ b/backend/app/templates/admin/partials/subdomain_blacklist_table.html
@@ -1,0 +1,46 @@
+{% if subdomain_blacklist %}
+<table class="theme-table">
+  <thead>
+    <tr>
+      <th scope="col">子域前缀</th>
+      <th scope="col">创建时间</th>
+      <th scope="col" class="theme-table__col-actions">
+        <span class="theme-table__col-actions-label">
+          <span class="theme-table__col-actions-text">操作</span>
+        </span>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in subdomain_blacklist %}
+    <tr id="subdomain-blacklist-row-{{ item.id }}" class="theme-table__row">
+      <td class="theme-table__cell theme-table__cell--summary">
+        <div class="theme-table__summary">
+          <span class="theme-table__summary-text">{{ item.label }}</span>
+        </div>
+      </td>
+      <td class="theme-table__cell theme-table__cell--muted">
+        {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '-' }}
+      </td>
+      <td class="theme-table__cell theme-table__cell--right theme-table__cell--actions">
+        <button
+          type="button"
+          class="theme-button theme-button--danger theme-button--sm"
+          hx-delete="/api/subdomain-blacklist/{{ item.id }}"
+          hx-target="#subdomain-blacklist-feedback"
+          hx-swap="innerHTML"
+          hx-confirm="确认移除该黑名单前缀？"
+          data-success-event="refresh-subdomain-blacklist"
+        >
+          删除
+        </button>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="theme-table__empty">
+  暂无黑名单，可在上方表单添加受限子域前缀。
+</div>
+{% endif %}

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -36,6 +36,10 @@
               autocomplete="off"
               spellcheck="false"
               data-domain-input-field
+              pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+              minlength="3"
+              maxlength="20"
+              title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
             />
             <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
             <input type="hidden" name="host" value="{{ item.host }}" data-domain-input-hidden />

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -20,6 +20,10 @@
               class="theme-input theme-input--wide"
               autocomplete="off"
               spellcheck="false"
+              pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
+              minlength="3"
+              maxlength="20"
+              title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
             />
           </div>
           <div class="theme-field theme-field--mobile-condensed">

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1280,7 +1280,91 @@
         padding: 1.35rem var(--theme-container-padding);
         font-size: 0.9rem;
         color: var(--theme-text-secondary);
-        background: rgba(255, 255, 255, 0.35);
+        background: transparent;
+      }
+
+      .theme-feedback__message {
+        display: inline-block;
+        padding: 0.85rem 1.1rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(148, 163, 184, 0.12);
+        color: var(--theme-text-primary);
+        font-size: 0.9rem;
+        line-height: 1.4;
+      }
+
+      .theme-feedback__message + .theme-feedback__message {
+        margin-top: 0.75rem;
+      }
+
+      .theme-feedback__message--success {
+        background: rgba(16, 185, 129, 0.15);
+        border-color: rgba(5, 150, 105, 0.35);
+        color: #047857;
+      }
+
+      .theme-feedback__message--info {
+        background: rgba(99, 102, 241, 0.14);
+        border-color: rgba(79, 70, 229, 0.35);
+        color: #3730a3;
+      }
+
+      .theme-feedback__message--warning {
+        background: rgba(251, 191, 36, 0.18);
+        border-color: rgba(217, 119, 6, 0.38);
+        color: #b45309;
+      }
+
+      .theme-feedback__message--error {
+        background: var(--theme-danger-bg);
+        border-color: var(--theme-danger-border);
+        color: var(--theme-danger-text);
+      }
+
+      .theme-feedback__code {
+        display: inline-block;
+        padding: 0.1rem 0.4rem;
+        border-radius: 0.5rem;
+        background: rgba(15, 23, 42, 0.08);
+        font-family: var(--font-mono);
+        font-size: 0.92em;
+        letter-spacing: 0.02em;
+      }
+
+      :root[data-theme="nebula"] .theme-feedback__message {
+        border-color: rgba(148, 163, 184, 0.3);
+        background: rgba(30, 41, 59, 0.65);
+        color: var(--theme-text-primary);
+      }
+
+      :root[data-theme="nebula"] .theme-feedback__message--success {
+        background: rgba(34, 197, 94, 0.22);
+        border-color: rgba(34, 197, 94, 0.45);
+        color: #bbf7d0;
+      }
+
+      :root[data-theme="nebula"] .theme-feedback__message--info {
+        background: rgba(59, 130, 246, 0.2);
+        border-color: rgba(59, 130, 246, 0.45);
+        color: #bfdbfe;
+      }
+
+      :root[data-theme="nebula"] .theme-feedback__message--warning {
+        background: rgba(234, 179, 8, 0.28);
+        border-color: rgba(234, 179, 8, 0.45);
+        color: #fde68a;
+      }
+
+      :root[data-theme="nebula"] .theme-feedback__message--error {
+        background: rgba(248, 113, 113, 0.2);
+        border-color: rgba(248, 113, 113, 0.45);
+        color: #fecaca;
+      }
+
+      :root[data-theme="nebula"] .theme-feedback__code {
+        background: rgba(148, 163, 184, 0.22);
+        color: var(--theme-text-primary);
       }
 
       .theme-login-feedback {

--- a/backend/app/validators.py
+++ b/backend/app/validators.py
@@ -1,0 +1,34 @@
+"""Reusable validation helpers for slug-like identifiers."""
+from __future__ import annotations
+
+import re
+
+
+_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$")
+
+
+def normalize_slug(value: str, *, field: str) -> str:
+    """Normalize and validate a slug value.
+
+    Slugs must consist of lowercase letters, digits, or hyphens, start and end
+    with an alphanumeric character, and be 3-20 characters long.
+    """
+
+    normalized = value.strip().lower()
+    if not normalized:
+        raise ValueError(f"{field}不能为空")
+    if not _SLUG_PATTERN.fullmatch(normalized):
+        raise ValueError(
+            f"{field}仅允许小写字母、数字或连字符，长度需为 3-20 且首尾为字母或数字"
+        )
+    return normalized
+
+
+def extract_subdomain_label(host: str) -> str:
+    """Return the leading label of a host for blacklist enforcement."""
+
+    normalized = host.strip().lower()
+    if not normalized:
+        return ""
+    return normalized.split(".", 1)[0]
+

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -21,7 +21,13 @@ from .deps import (
     validate_credentials,
 )
 from .session import clear_session, get_session
-from .models import ShortLink, SiteSettings, SubdomainRedirect, User
+from .models import (
+    ShortLink,
+    SiteSettings,
+    SubdomainBlacklist,
+    SubdomainRedirect,
+    User,
+)
 from .settings_service import build_short_link_prefix, get_site_settings
 
 SUBDOMAIN_CODE_OPTIONS = [302, 301]
@@ -61,6 +67,14 @@ def _load_subdomains(db: Session, user: User) -> list[SubdomainRedirect]:
     return list(db.scalars(query).all())
 
 
+def _load_subdomain_blacklist(db: Session) -> list[SubdomainBlacklist]:
+    return list(
+        db.scalars(
+            select(SubdomainBlacklist).order_by(SubdomainBlacklist.label.asc())
+        ).all()
+    )
+
+
 def _load_users(db: Session) -> list[User]:
     return list(
         db.scalars(select(User).order_by(User.created_at.desc())).all()
@@ -70,7 +84,7 @@ def _load_users(db: Session) -> list[User]:
 def _generate_short_link_suggestion(db: Session, length: int) -> str:
     """Generate a random short link code suggestion that does not clash with existing ones."""
 
-    alphabet = string.ascii_letters + string.digits
+    alphabet = string.ascii_lowercase + string.digits
     attempts = max(length * 2, 10)
     for _ in range(attempts):
         candidate = "".join(secrets.choice(alphabet) for _ in range(length))
@@ -159,12 +173,15 @@ def admin_dashboard(
             "subdomain_code_options": SUBDOMAIN_CODE_OPTIONS,
             "show_user_column": current_user.is_admin,
             "short_link_example": f"{context['short_link_prefix']}example",
+            "subdomain_blacklist": _load_subdomain_blacklist(db)
+            if current_user.is_admin
+            else [],
         }
     )
     if current_user.is_admin and active_tab == "settings":
         if request.query_params.get("saved"):
             context["settings_feedback_html"] = (
-                "<div class=\"rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700\">"
+                "<div class=\"theme-feedback__message theme-feedback__message--success\">"
                 "站点设置已更新"
                 "</div>"
             )
@@ -363,6 +380,25 @@ def subdomain_table(
     context, _ = _context_with_settings(request, db, current_user)
     context.update({"subdomains": subdomains, "show_user_column": current_user.is_admin})
     return templates.TemplateResponse("admin/partials/subdomain_table.html", context)
+
+
+@router.get(
+    "/admin/subdomains/blacklist/table",
+    response_class=HTMLResponse,
+)
+def subdomain_blacklist_table(
+    request: Request,
+    admin: User = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """返回子域黑名单表格片段。"""
+
+    entries = _load_subdomain_blacklist(db)
+    context, _ = _context_with_settings(request, db, admin)
+    context.update({"subdomain_blacklist": entries})
+    return templates.TemplateResponse(
+        "admin/partials/subdomain_blacklist_table.html", context
+    )
 
 
 @router.get(

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -6,19 +6,19 @@ ADMIN_AUTH = ("admin", "admin")
 def test_routes_endpoint_lists_subdomains(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "a.test", "target_url": "https://example.com/a"},
+        json={"host": "alpha.test", "target_url": "https://example.com/a"},
         auth=ADMIN_AUTH,
     )
     client.post(
         "/api/subdomains",
-        json={"host": "b.test", "target_url": "https://example.com/b"},
+        json={"host": "beta.test", "target_url": "https://example.com/b"},
         auth=ADMIN_AUTH,
     )
 
     response = client.get("/routes")
     assert response.status_code == 200
     hosts = [item["host"] for item in response.json()]
-    assert hosts == ["a.test", "b.test"]
+    assert hosts == ["alpha.test", "beta.test"]
 
 
 def test_fallback_redirect_strips_site_domain_path(client: "SimpleClient") -> None:

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -32,14 +32,25 @@ def test_create_short_link_conflict(client: "SimpleClient") -> None:
     assert conflict.json() == {"error": "短链接编码已存在"}
 
 
+def test_create_short_link_invalid_code(client: "SimpleClient") -> None:
+    response = client.post(
+        "/api/links",
+        json={"target_url": "https://example.com", "code": "-bad"},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any("短链编码" in item.get("msg", "") for item in detail)
+
+
 def test_redirect_short_link_and_hits(client: "SimpleClient") -> None:
     client.post(
         "/api/links",
-        json={"target_url": "https://example.com/landing", "code": "go"},
+        json={"target_url": "https://example.com/landing", "code": "go1"},
         auth=ADMIN_AUTH,
     )
 
-    redirect = client.get("/go", headers={"host": "yet.la"}, follow_redirects=False)
+    redirect = client.get("/go1", headers={"host": "yet.la"}, follow_redirects=False)
     assert redirect.status_code == 302
     assert redirect.headers["location"] == "https://example.com/landing"
 

--- a/backend/tests/test_subdomains.py
+++ b/backend/tests/test_subdomains.py
@@ -33,6 +33,17 @@ def test_create_subdomain_conflict(client: "SimpleClient") -> None:
     assert conflict.json() == {"error": "子域跳转已存在"}
 
 
+def test_create_subdomain_invalid_prefix(client: "SimpleClient") -> None:
+    response = client.post(
+        "/api/subdomains",
+        json={"host": "-bad.test", "target_url": "https://example.com/bad"},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any("子域" in item.get("msg", "") for item in detail)
+
+
 def test_delete_subdomain(client: "SimpleClient") -> None:
     created = client.post(
         "/api/subdomains",
@@ -71,6 +82,55 @@ def test_update_subdomain_via_htmx_form(client: "SimpleClient") -> None:
     records = listing.json()
     assert records[0]["target_url"] == "https://example.com/new"
     assert records[0]["code"] == 301
+
+
+def test_subdomain_blacklist_blocks_creation(client: "SimpleClient") -> None:
+    entry = client.post(
+        "/api/subdomain-blacklist",
+        json={"label": "blocked"},
+        auth=ADMIN_AUTH,
+    )
+    assert entry.status_code == 201
+
+    denied = client.post(
+        "/api/subdomains",
+        json={"host": "blocked.test", "target_url": "https://example.com/blocked"},
+        auth=ADMIN_AUTH,
+    )
+    assert denied.status_code == 422
+    assert denied.json() == {"detail": "子域前缀已在黑名单中"}
+
+    listing = client.get("/api/subdomain-blacklist", auth=ADMIN_AUTH)
+    assert listing.status_code == 200
+    payload = listing.json()
+    assert any(item["label"] == "blocked" for item in payload)
+
+    delete = client.delete(
+        f"/api/subdomain-blacklist/{entry.json()['id']}", auth=ADMIN_AUTH
+    )
+    assert delete.status_code == 204
+
+
+def test_subdomain_blacklist_blocks_updates(client: "SimpleClient") -> None:
+    redirect = client.post(
+        "/api/subdomains",
+        json={"host": "safe.test", "target_url": "https://example.com/safe"},
+        auth=ADMIN_AUTH,
+    ).json()
+
+    client.post(
+        "/api/subdomain-blacklist",
+        json={"label": "blocked"},
+        auth=ADMIN_AUTH,
+    )
+
+    response = client.put(
+        f"/api/subdomains/{redirect['id']}",
+        json={"host": "blocked.test", "target_url": "https://example.com/new", "code": 302},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 422
+    assert response.json() == {"detail": "子域前缀已在黑名单中"}
 
 
 def test_host_redirect_status_codes(client: "SimpleClient") -> None:

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -44,6 +44,22 @@ def test_admin_can_create_update_delete_user(client: "SimpleClient") -> None:
     assert deleted.headers.get("hx-trigger") == "refresh-users"
 
 
+def test_create_user_invalid_username(client: "SimpleClient") -> None:
+    response = client.post(
+        "/api/users",
+        json={
+            "username": "bad_name",
+            "email": "bad@example.com",
+            "password": "badpass",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 422
+    detail = response.json().get("detail", [])
+    assert any("用户名" in item.get("msg", "") for item in detail)
+
+
 def test_non_admin_cannot_access_user_management(client: "SimpleClient") -> None:
     client.post(
         "/api/users",


### PR DESCRIPTION
## Summary
- enforce a shared slug whitelist for short link codes, subdomain hosts, and usernames while updating admin forms to match
- store and expose a subdomain blacklist with new API endpoints and dashboard sections, including HTMX table partials
- refresh feedback messaging styles for HTMX responses and extend tests for validation errors and blacklist behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e5c257b384832f9daa8cb774727477