### PR TITLE
feat(admin): manage subdomain blacklist and relax admin limits

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from .schemas import (
     SiteSettingsUpdate,
     SubdomainBlacklist as SubdomainBlacklistSchema,
     SubdomainBlacklistCreate,
+    SubdomainBlacklistBulkUpdate,
     SubdomainRedirect as SubdomainRedirectSchema,
     SubdomainRedirectCreate,
     SubdomainRedirectUpdate,
@@ -62,7 +63,8 @@ from .settings_service import (
     resolve_short_link_hosts,
     update_site_settings,
 )
-from .validators import extract_subdomain_label
+from .subdomain_service import ensure_default_subdomain_blacklist
+from .validators import extract_subdomain_label, normalize_slug
 
 MAX_CODE_ATTEMPTS = 10
 
@@ -115,6 +117,7 @@ def ensure_tables() -> None:
         ensure_user_association_columns()
         ensure_default_settings()
         ensure_default_admin()
+        ensure_default_subdomain_blacklist()
     except SQLAlchemyError as exc:  # pragma: no cover - 依赖数据库环境
         raise RuntimeError("failed to initialize database schema") from exc
 
@@ -217,6 +220,14 @@ async def _read_form_data(request: Request, content_type: str) -> dict[str, Any]
     return {key: value for key, value in form.multi_items()}
 
 
+def _ensure_slug_length(value: str, *, field: str) -> None:
+    if not 3 <= len(value) <= 20:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"{field}长度需为 3-20 个字符",
+        )
+
+
 def _ensure_short_link_permission(short_link: ShortLink, user: User) -> None:
     if user.is_admin:
         return
@@ -231,7 +242,9 @@ def _ensure_subdomain_permission(redirect: SubdomainRedirect, user: User) -> Non
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="无权操作该子域")
 
 
-def _ensure_subdomain_not_blacklisted(db: Session, host: str) -> None:
+def _ensure_subdomain_not_blacklisted(db: Session, host: str, user: User) -> None:
+    if user.is_admin:
+        return
     label = extract_subdomain_label(host)
     if not label:
         return
@@ -331,6 +344,24 @@ async def _parse_subdomain_blacklist_payload(
 
     try:
         return SubdomainBlacklistCreate.model_validate(data)
+    except ValidationError as exc:  # pragma: no cover - FastAPI 统一处理
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_serialize_validation_detail(exc.errors()),
+        ) from exc
+
+
+async def _parse_subdomain_blacklist_bulk_payload(
+    request: Request,
+) -> SubdomainBlacklistBulkUpdate:
+    content_type = request.headers.get("content-type", "").lower()
+    if content_type.startswith("application/json"):
+        data = await request.json()
+    else:
+        data = await _read_form_data(request, content_type)
+
+    try:
+        return SubdomainBlacklistBulkUpdate.model_validate(data)
     except ValidationError as exc:  # pragma: no cover - FastAPI 统一处理
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -593,6 +624,8 @@ async def create_short_link(
 
     settings = get_site_settings(db)
     code = payload.code
+    if code and not current_user.is_admin:
+        _ensure_slug_length(code, field="短链编码")
     if code:
         exists = db.scalar(select(ShortLink).where(ShortLink.code == code))
         if exists:
@@ -666,6 +699,8 @@ async def update_short_link(
     _ensure_short_link_permission(short_link, current_user)
 
     if payload.code != short_link.code:
+        if not current_user.is_admin:
+            _ensure_slug_length(payload.code, field="短链编码")
         exists = db.scalar(select(ShortLink).where(ShortLink.code == payload.code))
         if exists:
             raise HTTPException(status.HTTP_409_CONFLICT, detail="短链接编码已存在")
@@ -726,7 +761,11 @@ async def create_subdomain(
     """创建子域跳转规则，Host 为完整域名。"""
 
     host = payload.host
-    _ensure_subdomain_not_blacklisted(db, host)
+    if not current_user.is_admin:
+        label = extract_subdomain_label(host)
+        if label:
+            _ensure_slug_length(label, field="子域前缀")
+    _ensure_subdomain_not_blacklisted(db, host, current_user)
     existing = db.scalar(select(SubdomainRedirect).where(SubdomainRedirect.host == host))
     if existing:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="子域跳转已存在")
@@ -809,6 +848,66 @@ async def create_subdomain_blacklist_entry(
 
     response.headers["HX-Trigger"] = "refresh-subdomain-blacklist"
     return entry
+
+
+@app.put(
+    "/api/subdomain-blacklist",
+    response_model=list[SubdomainBlacklistSchema],
+)
+async def replace_subdomain_blacklist(
+    request: Request,
+    response: Response,
+    payload: SubdomainBlacklistBulkUpdate = Depends(
+        _parse_subdomain_blacklist_bulk_payload
+    ),
+    _admin: User = Depends(require_admin_user),
+    db: Session = Depends(get_db),
+) -> list[SubdomainBlacklist] | HTMLResponse:
+    """替换整份子域黑名单列表。"""
+
+    raw_labels = payload.labels.split()
+    normalized_labels: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_labels:
+        try:
+            normalized = normalize_slug(raw, field="子域")
+        except ValueError as exc:  # pragma: no cover - 输入校验
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+            ) from exc
+        if normalized not in seen:
+            normalized_labels.append(normalized)
+            seen.add(normalized)
+
+    existing_entries = db.scalars(select(SubdomainBlacklist)).all()
+    existing_by_label = {entry.label: entry for entry in existing_entries}
+    desired = set(normalized_labels)
+
+    for entry in existing_entries:
+        if entry.label not in desired:
+            db.delete(entry)
+
+    for label in normalized_labels:
+        if label not in existing_by_label:
+            db.add(SubdomainBlacklist(label=label))
+
+    _commit_session(db)
+
+    updated_entries = db.scalars(
+        select(SubdomainBlacklist).order_by(SubdomainBlacklist.label.asc())
+    ).all()
+
+    hx_request = request.headers.get("hx-request") == "true"
+    if hx_request:
+        message = _feedback_html("子域黑名单已保存", tone="success")
+        return HTMLResponse(
+            message,
+            status_code=status.HTTP_200_OK,
+            headers={"HX-Trigger": "refresh-subdomain-blacklist"},
+        )
+
+    response.headers["HX-Trigger"] = "refresh-subdomain-blacklist"
+    return list(updated_entries)
 
 
 @app.delete("/api/subdomain-blacklist/{entry_id}")
@@ -1072,7 +1171,11 @@ async def update_subdomain(
 
     normalized_host = payload.host
     if normalized_host != redirect.host:
-        _ensure_subdomain_not_blacklisted(db, normalized_host)
+        if not current_user.is_admin:
+            label = extract_subdomain_label(normalized_host)
+            if label:
+                _ensure_slug_length(label, field="子域前缀")
+        _ensure_subdomain_not_blacklisted(db, normalized_host, current_user)
         exists = db.scalar(
             select(SubdomainRedirect).where(SubdomainRedirect.host == normalized_host)
         )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -79,6 +79,15 @@ class SubdomainBlacklistCreate(SubdomainBlacklistBase):
     pass
 
 
+class SubdomainBlacklistBulkUpdate(BaseModel):
+    labels: str = Field("", description="以空格分隔的子域前缀列表")
+
+    @field_validator("labels")
+    @classmethod
+    def _normalize_labels(cls, value: str) -> str:
+        return " ".join(value.split())
+
+
 class ShortLinkBase(BaseModel):
     target_url: str = Field(..., description="目标地址")
 

--- a/backend/app/subdomain_service.py
+++ b/backend/app/subdomain_service.py
@@ -1,0 +1,94 @@
+"""Helpers for managing subdomain blacklist defaults and utilities."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from sqlalchemy import select
+
+from .models import SessionLocal, SubdomainBlacklist
+from .validators import normalize_slug
+
+
+DEFAULT_SUBDOMAIN_BLACKLIST_LABELS: tuple[str, ...] = (
+    "www",
+    "mail",
+    "ftp",
+    "smtp",
+    "imap",
+    "pop",
+    "api",
+    "admin",
+    "root",
+    "sys",
+    "dns",
+    "ns1",
+    "ns2",
+    "server",
+    "gateway",
+    "proxy",
+    "router",
+    "test",
+    "sandbox",
+    "staging",
+    "beta",
+    "status",
+    "static",
+    "cdn",
+    "ssl",
+    "secure",
+    "login",
+    "signup",
+    "register",
+    "account",
+    "user",
+    "support",
+    "helpdesk",
+    "contact",
+    "pay",
+    "wallet",
+    "billing",
+    "invoice",
+    "bank",
+    "auth",
+    "verify",
+    "identity",
+    "google",
+    "facebook",
+    "twitter",
+    "apple",
+    "amazon",
+    "microsoft",
+    "paypal",
+    "openai",
+    "localhost",
+    "example",
+    "invalid",
+    "internal",
+    "local",
+    "lan",
+    "home",
+    "loopback",
+)
+
+
+def ensure_default_subdomain_blacklist() -> None:
+    """Ensure the default blacklist labels exist in the database."""
+
+    with SessionLocal() as session:
+        existing = {label for label in session.scalars(select(SubdomainBlacklist.label))}
+        missing = [
+            normalize_slug(label, field="子域")
+            for label in DEFAULT_SUBDOMAIN_BLACKLIST_LABELS
+            if label not in existing
+        ]
+        if not missing:
+            return
+        session.add_all(SubdomainBlacklist(label=label) for label in missing)
+        session.commit()
+
+
+def format_blacklist_labels(labels: Iterable[SubdomainBlacklist]) -> str:
+    """Join blacklist labels into a single space separated string."""
+
+    return " ".join(entry.label for entry in labels)
+

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -98,10 +98,8 @@
                       autocomplete="off"
                       spellcheck="false"
                       placeholder="自动生成，可修改"
-                      pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-                      minlength="3"
-                      maxlength="20"
-                      title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+                      pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+                      title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
                     />
                   </div>
                 </div>
@@ -187,10 +185,8 @@
                       autocomplete="off"
                       spellcheck="false"
                       data-domain-input-field
-                      pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-                      minlength="3"
-                      maxlength="20"
-                      title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+                      pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+                      title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
                     />
                     <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
                     <input type="hidden" name="host" data-domain-input-hidden />
@@ -250,9 +246,9 @@
         {% if current_user and current_user.is_admin %}
         <section class="theme-card">
           <div class="theme-card__header">
-            <h2 class="theme-card__title">创建子域黑名单</h2>
+            <h2 class="theme-card__title">管理子域黑名单</h2>
             <p class="theme-card__subtitle">
-              添加受限前缀，阻止创建或修改到这些子域名。
+              使用空格分隔多个子域前缀，保存后普通用户将无法使用这些前缀。
             </p>
           </div>
           <div class="theme-card__body">
@@ -260,35 +256,27 @@
               class="theme-form"
               action="/api/subdomain-blacklist"
               method="post"
-              hx-post="/api/subdomain-blacklist"
+              hx-put="/api/subdomain-blacklist"
               hx-trigger="submit"
               hx-target="#subdomain-blacklist-feedback"
               hx-swap="innerHTML"
-              data-reset-on-success="true"
-              data-success-event="refresh-subdomain-blacklist"
             >
-              <div class="theme-form__grid theme-form__grid--two">
-                <div class="theme-field theme-form__span-full theme-field--mobile-condensed">
-                  <label for="blacklist-label" class="theme-label">子域前缀 *</label>
-                  <input
-                    id="blacklist-label"
-                    name="label"
-                    type="text"
-                    required
-                    class="theme-input theme-input--wide"
-                    placeholder="如 marketing"
-                    autocomplete="off"
-                    spellcheck="false"
-                    pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-                    minlength="3"
-                    maxlength="20"
-                    title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
-                  />
-                </div>
+              <div class="theme-field theme-form__span-full theme-field--mobile-condensed">
+                <label for="subdomain-blacklist-labels" class="theme-label">屏蔽前缀列表</label>
+                <textarea
+                  id="subdomain-blacklist-labels"
+                  name="labels"
+                  class="theme-textarea"
+                  rows="4"
+                  placeholder="例如：www api admin"
+                  spellcheck="false">{{ subdomain_blacklist_text }}</textarea>
               </div>
+              <p class="theme-help-text">
+                使用空格分隔多个子域前缀，管理员可随时调整；普通用户创建或修改子域时将受到限制。
+              </p>
               <div class="theme-form__footer theme-form__footer--center">
                 <button type="submit" class="theme-button theme-button--solid">
-                  添加黑名单
+                  保存屏蔽列表
                 </button>
               </div>
             </form>
@@ -299,23 +287,6 @@
             role="status"
             aria-live="polite"
           ></div>
-        </section>
-        <section class="theme-card">
-          <div class="theme-card__header">
-            <h2 class="theme-card__title">子域黑名单列表</h2>
-            <p class="theme-card__subtitle">
-              当前受限制的子域前缀，命中将无法创建或修改。
-            </p>
-          </div>
-          <div
-            id="subdomain-blacklist-table"
-            class="theme-card__body theme-card__body--table"
-            hx-get="/admin/subdomains/blacklist/table"
-            hx-trigger="load, refresh-subdomain-blacklist from:body"
-            hx-swap="innerHTML"
-          >
-            {% include "admin/partials/subdomain_blacklist_table.html" %}
-          </div>
         </section>
         {% endif %}
       </div>
@@ -353,10 +324,8 @@
                       placeholder="如 alice"
                       autocomplete="off"
                       spellcheck="false"
-                      pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-                      minlength="3"
-                      maxlength="20"
-                      title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+                      pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+                      title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
                     />
                   </div>
                   <div class="theme-field theme-field--mobile-condensed">

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -46,10 +46,8 @@
                 autocomplete="username"
                 spellcheck="false"
                 value="{{ username_value }}"
-                pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-                minlength="3"
-                maxlength="20"
-                title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+                pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+                title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
               />
             </div>
             <div class="theme-field">

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -21,10 +21,8 @@
               class="theme-input-affix__input"
               autocomplete="off"
               spellcheck="false"
-              pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-              minlength="3"
-              maxlength="20"
-              title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+              pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+              title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
             />
           </div>
         </div>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -36,10 +36,8 @@
               autocomplete="off"
               spellcheck="false"
               data-domain-input-field
-              pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-              minlength="3"
-              maxlength="20"
-              title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+              pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+              title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
             />
             <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
             <input type="hidden" name="host" value="{{ item.host }}" data-domain-input-hidden />

--- a/backend/app/templates/admin/partials/user_edit_row.html
+++ b/backend/app/templates/admin/partials/user_edit_row.html
@@ -20,10 +20,8 @@
               class="theme-input theme-input--wide"
               autocomplete="off"
               spellcheck="false"
-              pattern="^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$"
-              minlength="3"
-              maxlength="20"
-              title="仅允许小写字母、数字或连字符，首尾为字母或数字，长度 3-20"
+              pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
+              title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
             />
           </div>
           <div class="theme-field theme-field--mobile-condensed">

--- a/backend/app/validators.py
+++ b/backend/app/validators.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import re
 
 
-_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{1,18}[a-z0-9])$")
+_SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$")
 
 
-def normalize_slug(value: str, *, field: str) -> str:
+def normalize_slug(value: str, *, field: str, enforce_length: bool = False) -> str:
     """Normalize and validate a slug value.
 
     Slugs must consist of lowercase letters, digits, or hyphens, start and end
@@ -18,9 +18,9 @@ def normalize_slug(value: str, *, field: str) -> str:
     if not normalized:
         raise ValueError(f"{field}不能为空")
     if not _SLUG_PATTERN.fullmatch(normalized):
-        raise ValueError(
-            f"{field}仅允许小写字母、数字或连字符，长度需为 3-20 且首尾为字母或数字"
-        )
+        raise ValueError(f"{field}仅允许小写字母、数字或连字符，且首尾需为字母或数字")
+    if enforce_length and not 3 <= len(normalized) <= 20:
+        raise ValueError(f"{field}长度需为 3-20 个字符")
     return normalized
 
 

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -29,6 +29,7 @@ from .models import (
     User,
 )
 from .settings_service import build_short_link_prefix, get_site_settings
+from .subdomain_service import format_blacklist_labels
 
 SUBDOMAIN_CODE_OPTIONS = [302, 301]
 
@@ -159,6 +160,7 @@ def admin_dashboard(
     short_links = _load_short_links(db, current_user)
     subdomains = _load_subdomains(db, current_user)
     users: list[User] = _load_users(db) if current_user.is_admin else []
+    blacklist_entries = _load_subdomain_blacklist(db) if current_user.is_admin else []
 
     context, settings = _context_with_settings(request, db, current_user)
     context.update(
@@ -173,9 +175,8 @@ def admin_dashboard(
             "subdomain_code_options": SUBDOMAIN_CODE_OPTIONS,
             "show_user_column": current_user.is_admin,
             "short_link_example": f"{context['short_link_prefix']}example",
-            "subdomain_blacklist": _load_subdomain_blacklist(db)
-            if current_user.is_admin
-            else [],
+            "subdomain_blacklist": blacklist_entries,
+            "subdomain_blacklist_text": format_blacklist_labels(blacklist_entries),
         }
     )
     if current_user.is_admin and active_tab == "settings":

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,12 +23,14 @@ from backend.app.models import (  # noqa: E402  pylint: disable=wrong-import-pos
     SessionLocal,
     ShortLink,
     SiteSettings,
+    SubdomainBlacklist,
     SubdomainRedirect,
     User,
     engine,
 )
 from backend.app.security import hash_password  # noqa: E402  pylint: disable=wrong-import-position
 from backend.app.settings_service import ensure_default_settings  # noqa: E402  pylint: disable=wrong-import-position
+from backend.app.subdomain_service import ensure_default_subdomain_blacklist  # noqa: E402  pylint: disable=wrong-import-position
 
 REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 
@@ -298,6 +300,7 @@ def _prepare_database() -> None:
             )
         )
         session.commit()
+    ensure_default_subdomain_blacklist()
     yield
     Base.metadata.drop_all(bind=engine)
     if TEST_DB_PATH.exists():
@@ -309,6 +312,7 @@ def _clean_database() -> None:
     with SessionLocal() as session:
         session.execute(delete(ShortLink))
         session.execute(delete(SubdomainRedirect))
+        session.execute(delete(SubdomainBlacklist))
         session.execute(delete(SiteSettings))
         session.execute(delete(User).where(User.username != ADMIN_USERNAME))
         admin = session.scalar(select(User).where(User.username == ADMIN_USERNAME))
@@ -328,10 +332,12 @@ def _clean_database() -> None:
             )
         session.commit()
     ensure_default_settings()
+    ensure_default_subdomain_blacklist()
     yield
     with SessionLocal() as session:
         session.execute(delete(ShortLink))
         session.execute(delete(SubdomainRedirect))
+        session.execute(delete(SubdomainBlacklist))
         session.execute(delete(User).where(User.username != ADMIN_USERNAME))
         admin = session.scalar(select(User).where(User.username == ADMIN_USERNAME))
         if admin is not None:
@@ -349,6 +355,7 @@ def _clean_database() -> None:
                 )
             )
         session.commit()
+    ensure_default_subdomain_blacklist()
 
 
 @pytest.fixture()

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -43,6 +43,42 @@ def test_create_short_link_invalid_code(client: "SimpleClient") -> None:
     assert any("短链编码" in item.get("msg", "") for item in detail)
 
 
+def test_admin_allows_long_short_code(client: "SimpleClient") -> None:
+    long_code = "adminlongshortcodevalue-1234567890"
+    response = client.post(
+        "/api/links",
+        json={"target_url": "https://example.com/admin", "code": long_code},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 201
+    created = response.json()
+    assert created["code"] == long_code
+
+    client.delete(f"/api/links/{created['id']}", auth=ADMIN_AUTH)
+
+
+def test_non_admin_short_code_length_enforced(client: "SimpleClient") -> None:
+    client.post(
+        "/api/users",
+        json={
+            "username": "shortuser",
+            "email": "shortuser@example.com",
+            "password": "shortpass",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+    user_auth = ("shortuser", "shortpass")
+
+    denied = client.post(
+        "/api/links",
+        json={"target_url": "https://example.com/nonadmin", "code": "ab"},
+        auth=user_auth,
+    )
+    assert denied.status_code == 422
+    assert denied.json() == {"detail": "短链编码长度需为 3-20 个字符"}
+
+
 def test_redirect_short_link_and_hits(client: "SimpleClient") -> None:
     client.post(
         "/api/links",

--- a/backend/tests/test_subdomains.py
+++ b/backend/tests/test_subdomains.py
@@ -92,13 +92,29 @@ def test_subdomain_blacklist_blocks_creation(client: "SimpleClient") -> None:
     )
     assert entry.status_code == 201
 
+    user_payload = {
+        "username": "blockeduser",
+        "email": "blockeduser@example.com",
+        "password": "blockedpass",
+        "is_admin": False,
+    }
+    client.post("/api/users", json=user_payload, auth=ADMIN_AUTH)
+    user_auth = ("blockeduser", "blockedpass")
+
     denied = client.post(
         "/api/subdomains",
         json={"host": "blocked.test", "target_url": "https://example.com/blocked"},
-        auth=ADMIN_AUTH,
+        auth=user_auth,
     )
     assert denied.status_code == 422
     assert denied.json() == {"detail": "子域前缀已在黑名单中"}
+
+    allowed = client.post(
+        "/api/subdomains",
+        json={"host": "blocked.test", "target_url": "https://example.com/allowed"},
+        auth=ADMIN_AUTH,
+    )
+    assert allowed.status_code == 201
 
     listing = client.get("/api/subdomain-blacklist", auth=ADMIN_AUTH)
     assert listing.status_code == 200
@@ -110,12 +126,27 @@ def test_subdomain_blacklist_blocks_creation(client: "SimpleClient") -> None:
     )
     assert delete.status_code == 204
 
+    created = allowed.json()
+    client.delete(f"/api/subdomains/{created['id']}", auth=ADMIN_AUTH)
+
 
 def test_subdomain_blacklist_blocks_updates(client: "SimpleClient") -> None:
+    client.post(
+        "/api/users",
+        json={
+            "username": "safeowner",
+            "email": "safeowner@example.com",
+            "password": "safeowner",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+    owner_auth = ("safeowner", "safeowner")
+
     redirect = client.post(
         "/api/subdomains",
         json={"host": "safe.test", "target_url": "https://example.com/safe"},
-        auth=ADMIN_AUTH,
+        auth=owner_auth,
     ).json()
 
     client.post(
@@ -127,10 +158,88 @@ def test_subdomain_blacklist_blocks_updates(client: "SimpleClient") -> None:
     response = client.put(
         f"/api/subdomains/{redirect['id']}",
         json={"host": "blocked.test", "target_url": "https://example.com/new", "code": 302},
-        auth=ADMIN_AUTH,
+        auth=owner_auth,
     )
     assert response.status_code == 422
     assert response.json() == {"detail": "子域前缀已在黑名单中"}
+
+    admin_update = client.put(
+        f"/api/subdomains/{redirect['id']}",
+        json={"host": "blocked.test", "target_url": "https://example.com/new", "code": 302},
+        auth=ADMIN_AUTH,
+    )
+    assert admin_update.status_code == 200
+    assert admin_update.json()["host"] == "blocked.test"
+
+    blacklist_listing = client.get("/api/subdomain-blacklist", auth=ADMIN_AUTH).json()
+    blocked_entry = next(item for item in blacklist_listing if item["label"] == "blocked")
+    client.delete(f"/api/subdomain-blacklist/{blocked_entry['id']}", auth=ADMIN_AUTH)
+
+    client.delete(f"/api/subdomains/{redirect['id']}", auth=ADMIN_AUTH)
+
+
+def test_non_admin_subdomain_length_enforced(client: "SimpleClient") -> None:
+    client.post(
+        "/api/users",
+        json={
+            "username": "shortprefix",
+            "email": "shortprefix@example.com",
+            "password": "shortpass",
+            "is_admin": False,
+        },
+        auth=ADMIN_AUTH,
+    )
+    user_auth = ("shortprefix", "shortpass")
+
+    denied = client.post(
+        "/api/subdomains",
+        json={"host": "xy.test", "target_url": "https://example.com/too-short"},
+        auth=user_auth,
+    )
+    assert denied.status_code == 422
+    assert denied.json() == {"detail": "子域前缀长度需为 3-20 个字符"}
+
+
+def test_admin_allows_short_subdomain_prefix(client: "SimpleClient") -> None:
+    response = client.post(
+        "/api/subdomains",
+        json={"host": "xy.test", "target_url": "https://example.com/admin"},
+        auth=ADMIN_AUTH,
+    )
+    assert response.status_code == 201
+    created = response.json()
+    assert created["host"] == "xy.test"
+
+    client.delete(f"/api/subdomains/{created['id']}", auth=ADMIN_AUTH)
+
+
+def test_admin_can_replace_subdomain_blacklist(client: "SimpleClient") -> None:
+    original_listing = client.get("/api/subdomain-blacklist", auth=ADMIN_AUTH)
+    assert original_listing.status_code == 200
+    original_payload = original_listing.json()
+    original_labels = " ".join(item["label"] for item in original_payload)
+    existing_labels = {item["label"] for item in original_payload}
+    assert {"www", "mail", "api"}.issubset(existing_labels)
+
+    try:
+        response = client.put(
+            "/api/subdomain-blacklist",
+            json={"labels": "alpha beta beta"},
+            auth=ADMIN_AUTH,
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert [entry["label"] for entry in payload] == ["alpha", "beta"]
+
+        refreshed = client.get("/api/subdomain-blacklist", auth=ADMIN_AUTH)
+        assert refreshed.status_code == 200
+        assert {item["label"] for item in refreshed.json()} == {"alpha", "beta"}
+    finally:
+        client.put(
+            "/api/subdomain-blacklist",
+            json={"labels": original_labels},
+            auth=ADMIN_AUTH,
+        )
 
 
 def test_host_redirect_status_codes(client: "SimpleClient") -> None:
@@ -241,7 +350,7 @@ def test_subdomains_are_scoped_by_user(client: "SimpleClient") -> None:
     user_auth = ("charlie", "charliepw")
     client.post(
         "/api/subdomains",
-        json={"host": "user.test", "target_url": "https://user.example.com"},
+        json={"host": "member.test", "target_url": "https://user.example.com"},
         auth=user_auth,
     )
 
@@ -249,11 +358,11 @@ def test_subdomains_are_scoped_by_user(client: "SimpleClient") -> None:
     assert user_listing.status_code == 200
     user_records = user_listing.json()
     assert len(user_records) == 1
-    assert user_records[0]["host"] == "user.test"
+    assert user_records[0]["host"] == "member.test"
 
     admin_listing = client.get("/api/subdomains", auth=ADMIN_AUTH)
     admin_hosts = {record["host"] for record in admin_listing.json()}
-    assert admin_hosts == {"admin-only.test", "user.test"}
+    assert admin_hosts == {"admin-only.test", "member.test"}
 
 
 def test_non_admin_cannot_modify_other_subdomains(client: "SimpleClient") -> None:


### PR DESCRIPTION
## Summary
- seed default subdomain blacklist entries and expose bulk update API for admins
- refresh admin subdomain management UI with editable blacklist textarea and loosen client-side slug limits
- allow admins to bypass slug length validation for short links, subdomains, and usernames while keeping checks for regular users

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_b_68e5caf0f5d0832f8634340346de7a2b