### PR TITLE
Adjust subdomain blacklist management form

### DIFF
--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -387,7 +387,7 @@
                 <textarea
                   id="subdomain-blacklist-labels"
                   name="labels"
-                  class="theme-input theme-input--wide theme-textarea"
+                  class="theme-input theme-textarea"
                   rows="4"
                   placeholder="例如：www api admin"
                   spellcheck="false">{{ subdomain_blacklist_text }}</textarea>
@@ -408,15 +408,6 @@
             role="status"
             aria-live="polite"
           ></div>
-          <div
-            id="subdomain-blacklist-table"
-            class="theme-card__body theme-card__body--table"
-            hx-get="/admin/subdomains/blacklist/table"
-            hx-trigger="load, refresh-subdomain-blacklist from:body"
-            hx-swap="innerHTML"
-          >
-            {% include "admin/partials/subdomain_blacklist_table.html" %}
-          </div>
         </section>
       </div>
       {% endif %}

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1067,6 +1067,11 @@
         max-width: 100%;
       }
 
+      .theme-textarea {
+        width: 100%;
+        font-family: inherit;
+      }
+
       @media (max-width: 640px) {
         .theme-input--compact {
           width: 100%;


### PR DESCRIPTION
## Summary
- remove the subdomain blacklist table from the settings card so only the form remains
- allow the blacklist textarea to span the full card width and inherit the standard input font

## Testing
- uvicorn backend.app.main:app --host 0.0.0.0 --port 8000 (manual UI verification)


------
https://chatgpt.com/codex/tasks/task_b_68e5d6e97d48832f89c2837005eb4f27