### PR TITLE
Improve admin validation messages and widen blacklist field

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -488,6 +488,21 @@ def _translate_validation_message(message: str) -> str:
     return message
 
 
+def _translate_field_name(field: str) -> str:
+    """将字段标识转换为更友好的中文标签。"""
+
+    mapping = {
+        "code": "短链代码",
+        "host": "子域前缀",
+        "labels": "屏蔽前缀列表",
+        "new_password": "新密码",
+        "password": "密码",
+        "target_url": "目标地址",
+        "username": "用户名",
+    }
+    return mapping.get(field, field)
+
+
 def _format_validation_errors(detail: Any) -> str:
     """将 Pydantic 错误信息转换为可读字符串。"""
 
@@ -505,6 +520,7 @@ def _format_validation_errors(detail: Any) -> str:
                 ),
                 "请求",
             )
+            field = _translate_field_name(field)
             raw_message = item.get("msg", "输入不合法")
             message = _translate_validation_message(str(raw_message))
             messages.append(f"{field}: {message}")

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -382,7 +382,7 @@
               hx-target="#subdomain-blacklist-feedback"
               hx-swap="innerHTML"
             >
-              <div class="theme-field theme-form__span-full theme-field--mobile-condensed">
+              <div class="theme-field theme-form__span-full theme-field--mobile-condensed theme-field--wide-desktop">
                 <label for="subdomain-blacklist-labels" class="theme-label">屏蔽前缀列表</label>
                 <textarea
                   id="subdomain-blacklist-labels"

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -1045,6 +1045,10 @@
         width: min(100%, 720px);
       }
 
+      .theme-field.theme-field--wide-desktop {
+        width: min(100%, 920px);
+      }
+
       .theme-input,
       .theme-select {
         width: 100%;
@@ -1074,6 +1078,10 @@
 
       @media (max-width: 640px) {
         .theme-input--compact {
+          width: 100%;
+        }
+
+        .theme-field.theme-field--wide-desktop {
           width: 100%;
         }
       }


### PR DESCRIPTION
## Summary
- translate validation error field names like host and target_url into localized labels
- widen the subdomain blacklist textarea on desktop layouts for better use of space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5ddca5ba0832fb0214ffcbda68973