### PR TITLE
Block Cloudflare analytics beacon on admin pages

### DIFF
--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -37,6 +37,138 @@
         }
       })();
     </script>
+    <script>
+      (function () {
+        var BLOCKED_HOSTS = ["static.cloudflareinsights.com"];
+
+        function isBlocked(value) {
+          if (!value || typeof value !== "string") {
+            return false;
+          }
+
+          try {
+            var url = new URL(value, window.location.href);
+            return BLOCKED_HOSTS.indexOf(url.hostname) !== -1;
+          } catch (error) {
+            for (var i = 0; i < BLOCKED_HOSTS.length; i += 1) {
+              if (value.indexOf(BLOCKED_HOSTS[i]) !== -1) {
+                return true;
+              }
+            }
+            return false;
+          }
+        }
+
+        function neutralize(script) {
+          if (!script || script.__cloudflareInsightsNeutralized) {
+            return;
+          }
+
+          script.__cloudflareInsightsNeutralized = true;
+
+          try {
+            script.type = "text/plain";
+            script.removeAttribute("src");
+          } catch (error) {
+            /* ignore */
+          }
+        }
+
+        function sanitizeScriptSource(element, srcValue) {
+          if (!element || element.tagName !== "SCRIPT") {
+            return false;
+          }
+
+          var source = srcValue;
+          if (!source) {
+            source = element.getAttribute("src") || element.src || "";
+          }
+
+          if (!isBlocked(source)) {
+            return false;
+          }
+
+          neutralize(element);
+          return true;
+        }
+
+        function sanitizeTree(node) {
+          if (!node) {
+            return;
+          }
+
+          if (sanitizeScriptSource(node)) {
+            return;
+          }
+
+          if (typeof node.querySelectorAll === "function") {
+            var scripts = node.querySelectorAll("script[src]");
+            for (var i = 0; i < scripts.length; i += 1) {
+              sanitizeScriptSource(scripts[i]);
+            }
+          }
+        }
+
+        var originalSetAttribute = Element.prototype.setAttribute;
+        Element.prototype.setAttribute = function (name, value) {
+          if (
+            name &&
+            typeof name === "string" &&
+            name.toLowerCase() === "src" &&
+            sanitizeScriptSource(this, value)
+          ) {
+            return;
+          }
+
+          return originalSetAttribute.call(this, name, value);
+        };
+
+        var descriptor = Object.getOwnPropertyDescriptor(
+          HTMLScriptElement.prototype,
+          "src",
+        );
+
+        if (descriptor && typeof descriptor.set === "function") {
+          var originalSet = descriptor.set;
+          Object.defineProperty(HTMLScriptElement.prototype, "src", {
+            configurable: true,
+            enumerable: descriptor.enumerable,
+            get: descriptor.get,
+            set: function (value) {
+              if (sanitizeScriptSource(this, value)) {
+                return value;
+              }
+
+              return originalSet.call(this, value);
+            },
+          });
+        }
+
+        var originalAppendChild = Node.prototype.appendChild;
+        Node.prototype.appendChild = function (child) {
+          sanitizeTree(child);
+          return originalAppendChild.call(this, child);
+        };
+
+        var originalInsertBefore = Node.prototype.insertBefore;
+        Node.prototype.insertBefore = function (newNode, referenceNode) {
+          sanitizeTree(newNode);
+          return originalInsertBefore.call(this, newNode, referenceNode);
+        };
+
+        function sweepExistingScripts() {
+          sanitizeTree(document.documentElement);
+        }
+
+        if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", sweepExistingScripts, {
+            once: true,
+          });
+        } else {
+          sweepExistingScripts();
+        }
+      })();
+    </script>
     <style>
       :root {
         color-scheme: light;


### PR DESCRIPTION
## Summary
- add a defensive inline script in the admin base template to neutralize Cloudflare Insights beacon injections
- ensure any dynamically inserted Cloudflare beacon scripts are converted to inert placeholders so Edge no longer reports failed network requests

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_b_68e5e2f9bcc4832f843491e243e76abd