### PR TITLE
feat: support multiple managed domains

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,7 +32,6 @@ from .models import (
     ensure_subdomain_hits_column,
     ensure_user_association_columns,
     engine,
-    DEFAULT_SITE_DOMAIN,
 )
 from .schemas import (
     ShortLink as ShortLinkSchema,
@@ -59,6 +58,7 @@ from .settings_service import (
     build_short_link_prefix,
     ensure_default_settings,
     extract_short_link,
+    get_primary_site_domain,
     get_site_settings,
     resolve_short_link_hosts,
     update_site_settings,
@@ -1265,10 +1265,7 @@ def catch_all(
     short_link_hosts = resolve_short_link_hosts(settings)
     allow_short_link = host in short_link_hosts
 
-    fallback_domain = (settings.site_domain or "").strip()
-    if "://" in fallback_domain:
-        fallback_domain = fallback_domain.split("://", 1)[1]
-    fallback_domain = fallback_domain.strip("/") or DEFAULT_SITE_DOMAIN
+    fallback_domain = get_primary_site_domain(settings.site_domain).strip()
     if "/" in fallback_domain:
         fallback_domain = fallback_domain.split("/", 1)[0]
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -205,7 +205,9 @@ class PasswordChange(BaseModel):
 
 
 class SiteSettingsBase(BaseModel):
-    site_domain: str = Field(..., description="基础域名，例如 yet.la")
+    site_domain: str = Field(
+        ..., description="管理域名，可使用空格分隔多个，首个为主域名"
+    )
     short_code_length: int = Field(..., ge=3, le=64, description="短链默认长度")
     short_link_path: str = Field(..., description="短链路径前缀，例如 / 或 /r/")
     logo_url: str = Field(..., description="LOGO 图片地址")

--- a/backend/app/settings_service.py
+++ b/backend/app/settings_service.py
@@ -21,14 +21,42 @@ _MIN_SHORT_CODE_LENGTH = 3
 _MAX_SHORT_CODE_LENGTH = 64
 
 
+def _normalize_site_domain_values(value: str | None) -> list[str]:
+    raw = (value or "").replace(",", " ")
+    candidates = [segment.strip() for segment in raw.split() if segment.strip()]
+    normalized: list[str] = []
+    seen: set[str] = set()
+
+    for candidate in candidates:
+        lowered = candidate.lower()
+        if lowered.startswith("http://") or lowered.startswith("https://"):
+            lowered = lowered.split("://", 1)[1]
+        lowered = lowered.split("/", 1)[0]
+        lowered = lowered.strip()
+        if not lowered:
+            continue
+        if lowered in seen:
+            continue
+        normalized.append(lowered)
+        seen.add(lowered)
+
+    if not normalized:
+        normalized.append(DEFAULT_SITE_DOMAIN)
+
+    return normalized
+
+
 def normalize_site_domain(value: str | None) -> str:
-    raw = (value or "").strip().lower()
-    if not raw:
-        return DEFAULT_SITE_DOMAIN
-    if raw.startswith("http://") or raw.startswith("https://"):
-        raw = raw.split("://", 1)[1]
-    raw = raw.split("/", 1)[0]
-    return raw or DEFAULT_SITE_DOMAIN
+    return " ".join(_normalize_site_domain_values(value))
+
+
+def split_site_domain_values(value: str | None) -> list[str]:
+    return _normalize_site_domain_values(value)
+
+
+def get_primary_site_domain(value: str | None) -> str:
+    domains = split_site_domain_values(value)
+    return domains[0] if domains else DEFAULT_SITE_DOMAIN
 
 
 def normalize_short_link_path(value: str | None) -> str:
@@ -52,15 +80,16 @@ def normalize_short_link_path(value: str | None) -> str:
 def resolve_short_link_hosts(settings: SiteSettings) -> set[str]:
     """Return hostnames that should trigger short link lookups."""
 
-    canonical = (settings.site_domain or "").strip().lower()
-    if not canonical:
-        return set()
-
-    hosts = {canonical}
-    if canonical.startswith("www."):
-        hosts.add(canonical[4:])
-    else:
-        hosts.add(f"www.{canonical}")
+    hosts: set[str] = set()
+    for domain in split_site_domain_values(settings.site_domain):
+        canonical = domain.strip().lower()
+        if not canonical:
+            continue
+        hosts.add(canonical)
+        if canonical.startswith("www."):
+            hosts.add(canonical[4:])
+        else:
+            hosts.add(f"www.{canonical}")
 
     return {host for host in hosts if host}
 
@@ -157,7 +186,7 @@ def update_site_settings(
 def build_short_link_prefix(settings: SiteSettings) -> str:
     """Compose the short link prefix shown in the UI."""
 
-    domain = settings.site_domain.strip().strip("/") or DEFAULT_SITE_DOMAIN
+    domain = get_primary_site_domain(settings.site_domain).strip().strip("/")
     base_url = f"https://{domain}".rstrip("/")
     path = settings.short_link_path
     if not path.startswith("/"):

--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -772,13 +772,25 @@
 
       const input = group.querySelector("[data-domain-input-field]");
       const hidden = group.querySelector("[data-domain-input-hidden]");
-      const rawSuffix = group.getAttribute("data-domain-suffix") || "";
-      const suffix = rawSuffix.trim();
+      const select = group.querySelector("[data-domain-input-select]");
+      const defaultSuffix = (group.getAttribute("data-domain-suffix") || "")
+        .trim()
+        .toLowerCase();
+
+      const resolveSuffix = () => {
+        if (select && select.value) {
+          return select.value.trim().toLowerCase();
+        }
+        return defaultSuffix;
+      };
 
       const updateValue = () => {
         if (!hidden) {
           return;
         }
+
+        const suffix = resolveSuffix();
+        group.dataset.domainSuffix = suffix;
 
         if (!input) {
           hidden.value = suffix;
@@ -806,6 +818,10 @@
 
       if (input) {
         input.addEventListener("input", updateValue);
+      }
+
+      if (select) {
+        select.addEventListener("change", updateValue);
       }
 
       const form = group.closest("form");

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -86,7 +86,21 @@
                 <div class="theme-field">
                   <label for="code" class="theme-label">短链（可改）</label>
                   <div class="theme-input-affix">
-                    <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_display_prefix }}</span>
+                    <span class="theme-input-affix__addon theme-input-affix__addon--prefix">
+                      <select
+                        id="short-link-domain"
+                        class="theme-input-affix__select"
+                        data-short-link-domain-select
+                        aria-label="选择短链域名"
+                      >
+                        {% for domain in managed_domains %}
+                        <option value="{{ domain }}">{{ domain }}</option>
+                        {% endfor %}
+                      </select>
+                      <span class="theme-input-affix__suffix-text" data-short-link-domain-suffix>
+                        {{ short_link_display_suffix }}
+                      </span>
+                    </span>
                     <input
                       id="code"
                       name="code"
@@ -153,7 +167,7 @@
           <div class="theme-card__header">
             <h2 class="theme-card__title">创建子域</h2>
             <p class="theme-card__subtitle">
-              填写子域前缀即可，后缀 .{{ base_domain }} 将自动拼接；状态码默认为 302，支持在下拉菜单中切换。
+              填写子域前缀并选择管理域名，系统会自动拼接完整主机；状态码默认为 302，可在下拉菜单中切换。
             </p>
           </div>
           <div class="theme-card__body">
@@ -174,7 +188,7 @@
                   <div
                     class="theme-input-affix"
                     data-domain-input
-                    data-domain-suffix="{{ base_domain }}"
+                    data-domain-suffix="{{ primary_domain }}"
                   >
                     <input
                       id="subdomain-prefix"
@@ -188,7 +202,19 @@
                       pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
                       title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
                     />
-                    <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
+                    <span class="theme-input-affix__addon theme-input-affix__addon--suffix">
+                      .
+                      <select
+                        id="subdomain-domain"
+                        class="theme-input-affix__select"
+                        data-domain-input-select
+                        aria-label="选择管理域名"
+                      >
+                        {% for domain in managed_domains %}
+                        <option value="{{ domain }}">{{ domain }}</option>
+                        {% endfor %}
+                      </select>
+                    </span>
                     <input type="hidden" name="host" data-domain-input-hidden />
                   </div>
                 </div>

--- a/backend/app/templates/admin/login.html
+++ b/backend/app/templates/admin/login.html
@@ -23,7 +23,7 @@
     <div class="theme-shell__body theme-shell__body--center theme-shell__body--auth">
       <section class="theme-card theme-card--narrow theme-card--auth">
         <div class="theme-card__header theme-card__header--center">
-          <h2 class="theme-card__title">登录 {{ site_settings.site_domain }} 管理后台</h2>
+          <h2 class="theme-card__title">登录 {{ primary_domain }} 管理后台</h2>
           <p class="theme-card__subtitle">输入账号与密码</p>
         </div>
         <div class="theme-card__body">

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -11,7 +11,21 @@
         <div class="theme-field">
           <label for="code-{{ item.id }}" class="theme-label">短链</label>
           <div class="theme-input-affix">
-            <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_display_prefix }}</span>
+            <span class="theme-input-affix__addon theme-input-affix__addon--prefix">
+              <select
+                id="short-link-domain-{{ item.id }}"
+                class="theme-input-affix__select"
+                data-short-link-domain-select
+                aria-label="选择短链域名"
+              >
+                {% for domain in managed_domains %}
+                <option value="{{ domain }}">{{ domain }}</option>
+                {% endfor %}
+              </select>
+              <span class="theme-input-affix__suffix-text" data-short-link-domain-suffix>
+                {{ short_link_display_suffix }}
+              </span>
+            </span>
             <input
               id="code-{{ item.id }}"
               name="code"

--- a/backend/app/templates/admin/partials/settings_card.html
+++ b/backend/app/templates/admin/partials/settings_card.html
@@ -27,10 +27,10 @@
             type="text"
             required
             class="theme-input theme-input--wide"
-            placeholder="如 yet.la"
+            placeholder="如 yet.la go2.you"
             value="{{ site_settings.site_domain }}"
           />
-          <p class="theme-hint">仅输入域名，无需协议。用于限制短链入口与界面展示。</p>
+          <p class="theme-hint">可填写多个域名，使用空格分隔；首个域名将用于界面展示。</p>
         </div>
         <div class="theme-field theme-field--mobile-condensed">
           <label for="short_code_length" class="theme-label">短链默认长度 *</label>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -10,28 +10,29 @@
       <div class="theme-form__grid theme-form__grid--three">
         <div class="theme-field">
           <label for="host-{{ item.id }}" class="theme-label">子域</label>
-          {% set domain_suffix = '' %}
-          {% set suffix = '' %}
-          {% if base_domain %}
-          {% set suffix = '.' ~ base_domain %}
-          {% if item.host.endswith(suffix) %}
-          {% set domain_suffix = base_domain %}
+          {% set domain_options = managed_domains if managed_domains else [base_domain] %}
+          {% set computed = namespace(domain=domain_options[0], prefix=item.host) %}
+          {% for option in domain_options %}
+          {% if item.host == option %}
+          {% set computed.domain = option %}
+          {% set computed.prefix = '' %}
+          {% break %}
+          {% elif item.host.endswith('.' ~ option) %}
+          {% set computed.domain = option %}
+          {% set computed.prefix = item.host[: item.host|length - ('.' ~ option)|length] %}
+          {% break %}
           {% endif %}
-          {% endif %}
-          {% set host_ns = namespace(value=item.host) %}
-          {% if domain_suffix %}
-          {% set host_ns.value = item.host[: item.host|length - ('.' ~ domain_suffix)|length] %}
-          {% endif %}
+          {% endfor %}
           <div
             class="theme-input-affix"
             data-domain-input
-            data-domain-suffix="{{ domain_suffix }}"
+            data-domain-suffix="{{ computed.domain }}"
           >
             <input
               id="host-{{ item.id }}"
               type="text"
               required
-              value="{{ host_ns.value }}"
+              value="{{ computed.prefix }}"
               class="theme-input-affix__input"
               autocomplete="off"
               spellcheck="false"
@@ -39,7 +40,19 @@
               pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
               title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
             />
-            <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
+            <span class="theme-input-affix__addon theme-input-affix__addon--suffix">
+              .
+              <select
+                id="host-domain-{{ item.id }}"
+                class="theme-input-affix__select"
+                data-domain-input-select
+                aria-label="选择管理域名"
+              >
+                {% for option in domain_options %}
+                <option value="{{ option }}" {% if option == computed.domain %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+            </span>
             <input type="hidden" name="host" value="{{ item.host }}" data-domain-input-hidden />
           </div>
         </div>

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>{% block title %}{{ site_settings.site_domain }} 短链子域管理后台{% endblock %}</title>
+    <title>{% block title %}{{ primary_domain }} 短链子域管理后台{% endblock %}</title>
     <link rel="icon" type="image/png" href="{{ site_settings.icon_url }}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -1151,6 +1151,34 @@
 
       .theme-input-affix__input::placeholder {
         color: var(--theme-muted);
+      }
+
+      .theme-input-affix__select {
+        border: none;
+        background: transparent;
+        color: var(--theme-text-primary);
+        font-family: var(--font-mono);
+        font-size: 0.9rem;
+        padding: 0 1.25rem 0 0.35rem;
+        margin-left: 0.25rem;
+        height: 100%;
+        cursor: pointer;
+      }
+
+      .theme-input-affix__select:focus,
+      .theme-input-affix__select:focus-visible {
+        outline: none;
+      }
+
+      .theme-input-affix__select option {
+        color: var(--theme-text-primary);
+        background: var(--theme-input-bg);
+      }
+
+      .theme-input-affix__suffix-text {
+        display: inline-flex;
+        align-items: center;
+        margin-left: 0.1rem;
       }
 
       .theme-helper {
@@ -2440,20 +2468,20 @@
               <div class="theme-hero__brand">
                 <img
                   src="{{ site_settings.logo_url }}"
-                  alt="{{ site_settings.site_domain }} 平台标识"
+                  alt="{{ primary_domain }} 平台标识"
                   class="theme-hero__brand-logo"
                 />
-                <span class="sr-only">{{ site_settings.site_domain }} Platform</span>
+                <span class="sr-only">{{ primary_domain }} Platform</span>
               </div>
             </div>
             <div class="theme-hero__toolbar">
               <div class="theme-hero__title-row">
                 <h1 class="theme-hero__title">
                   <span class="theme-hero__title-text theme-hero__title-text--full"
-                    >{{ site_settings.site_domain }} 短链子域管理后台</span
+                    >{{ primary_domain }} 短链子域管理后台</span
                   >
                   <span class="theme-hero__title-text theme-hero__title-text--compact"
-                    >{{ site_settings.site_domain }} 短链子域管理后台</span
+                    >{{ primary_domain }} 短链子域管理后台</span
                   >
                 </h1>
               </div>
@@ -2532,6 +2560,6 @@
     <main class="theme-main">
       {% block content %}{% endblock %}
     </main>
-    <footer class="theme-footer">© {{ current_year }} {{ site_settings.site_domain }}</footer>
+    <footer class="theme-footer">© {{ current_year }} {{ primary_domain }}</footer>
   </body>
 </html>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -28,7 +28,12 @@ from .models import (
     SubdomainRedirect,
     User,
 )
-from .settings_service import build_short_link_prefix, get_site_settings
+from .settings_service import (
+    build_short_link_prefix,
+    get_primary_site_domain,
+    get_site_settings,
+    split_site_domain_values,
+)
 from .subdomain_service import format_blacklist_labels
 
 SUBDOMAIN_CODE_OPTIONS = [302, 301]
@@ -98,7 +103,9 @@ def _generate_short_link_suggestion(db: Session, length: int) -> str:
 def _base_context(
     request: Request, settings: SiteSettings, user: User | None = None
 ) -> dict[str, Any]:
-    base_domain = settings.site_domain.strip().strip("/") or settings.site_domain
+    managed_domains = split_site_domain_values(settings.site_domain)
+    primary_domain = get_primary_site_domain(settings.site_domain)
+    base_domain = primary_domain.strip().strip("/") or primary_domain
     base_url = f"https://{base_domain}".rstrip("/")
     short_link_prefix = build_short_link_prefix(settings)
     short_link_display_prefix = short_link_prefix
@@ -106,14 +113,20 @@ def _base_context(
         if short_link_display_prefix.startswith(scheme):
             short_link_display_prefix = short_link_display_prefix[len(scheme) :]
             break
+    short_link_display_suffix = short_link_display_prefix
+    if short_link_display_prefix.startswith(primary_domain):
+        short_link_display_suffix = short_link_display_prefix[len(primary_domain) :]
     return {
         "request": request,
         "base_domain": base_domain,
         "base_url": base_url,
         "short_link_prefix": short_link_prefix,
         "short_link_display_prefix": short_link_display_prefix,
+        "short_link_display_suffix": short_link_display_suffix,
         "short_code_length": settings.short_code_length,
         "site_settings": settings,
+        "managed_domains": managed_domains,
+        "primary_domain": primary_domain,
         "current_year": datetime.utcnow().year,
         "settings_feedback_html": None,
         "show_logout_button": True,

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -51,6 +51,31 @@ def test_update_settings_affects_short_links(client: "SimpleClient") -> None:
     assert missing.status_code == 404
 
 
+def test_update_settings_supports_multiple_domains(client: "SimpleClient") -> None:
+    payload = {
+        "site_domain": "Yet.LA go2.you www.example.com",
+        "short_code_length": "6",
+        "short_link_path": "/",
+        "logo_url": "https://cdn.example.com/logo.png",
+        "icon_url": "https://cdn.example.com/icon.png",
+    }
+
+    response = client.put(
+        "/api/settings",
+        data=payload,
+        auth=(ADMIN_USERNAME, ADMIN_PASSWORD),
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["site_domain"] == "yet.la go2.you www.example.com"
+
+    fetched = client.get("/api/settings", auth=(ADMIN_USERNAME, ADMIN_PASSWORD))
+    assert fetched.status_code == 200
+    fetched_body = fetched.json()
+    assert fetched_body["site_domain"] == "yet.la go2.you www.example.com"
+
+
 def test_update_settings_via_htmx_returns_partial(client: "SimpleClient") -> None:
     payload = {
         "site_domain": "yet.la",

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -191,6 +191,43 @@ def test_redirect_short_link_not_found(client: "SimpleClient") -> None:
     assert response.headers["location"] == "https://yet.la"
 
 
+def test_short_link_redirect_on_secondary_domain(client: "SimpleClient") -> None:
+    update = client.put(
+        "/api/settings",
+        data={
+            "site_domain": "yet.la go2.you",
+            "short_code_length": "6",
+            "short_link_path": "/",
+            "logo_url": "https://img.example.com/logo.png",
+            "icon_url": "https://img.example.com/icon.png",
+        },
+        auth=ADMIN_AUTH,
+    )
+    assert update.status_code == 200
+
+    client.post(
+        "/api/links",
+        json={"target_url": "https://example.com/landing", "code": "promo"},
+        auth=ADMIN_AUTH,
+    )
+
+    redirect = client.get(
+        "/promo",
+        headers={"host": "go2.you"},
+        follow_redirects=False,
+    )
+    assert redirect.status_code == 302
+    assert redirect.headers["location"] == "https://example.com/landing"
+
+    missing = client.get(
+        "/missing",
+        headers={"host": "go2.you"},
+        follow_redirects=False,
+    )
+    assert missing.status_code == 302
+    assert missing.headers["location"] == "https://go2.you"
+
+
 def test_missing_short_link_with_path_avoids_subdomain_loop(
     client: "SimpleClient",
 ) -> None:


### PR DESCRIPTION
## Summary
- normalize and persist multiple managed domains while exposing helper utilities for primary/alternate hosts
- update admin UI templates and assets to offer domain selection when creating or editing short links and subdomains
- adjust display copy to use the primary domain and extend tests for multi-domain routing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e5fb630da4832f8bf778a43c27dbfe