### PR TITLE
Gracefully handle admin login without python-multipart

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -6,6 +6,7 @@ import string
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qsl
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -43,6 +44,33 @@ TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
 router = APIRouter()
+
+
+async def _read_login_form(request: Request) -> dict[str, str]:
+    """Parse login form submissions while tolerating missing python-multipart."""
+
+    try:
+        form = await request.form()
+    except AssertionError as exc:
+        content_type = (request.headers.get("content-type") or "").lower()
+        if content_type.startswith("application/x-www-form-urlencoded"):
+            charset = "utf-8"
+            if "charset=" in content_type:
+                charset = (
+                    content_type.split("charset=")[-1].split(";")[0].strip() or "utf-8"
+                )
+            try:
+                body = (await request.body()).decode(charset)
+            except UnicodeDecodeError as decode_exc:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST, detail="表单内容解码失败"
+                ) from decode_exc
+            return {key: value for key, value in parse_qsl(body, keep_blank_values=False)}
+        raise HTTPException(
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="缺少 python-multipart 依赖，无法解析表单上传",
+        ) from exc
+    return {key: value for key, value in form.multi_items()}
 
 
 def _safe_redirect_target(target: str | None) -> str:
@@ -261,7 +289,7 @@ async def admin_login_submit(
 ) -> HTMLResponse:
     """Handle login submissions and persist session state on success."""
 
-    form = await request.form()
+    form = await _read_login_form(request)
     username = (form.get("username") or "").strip()
     password = form.get("password") or ""
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from starlette.requests import Request
 
 def test_protected_endpoints_require_basic_auth(client: "SimpleClient") -> None:
     response = client.get("/api/links")
@@ -31,6 +32,27 @@ def test_login_flow_success(client: "SimpleClient") -> None:
     assert response.status_code == 200
     assert "创建短链" in response.text
     assert "改密" in response.text
+
+    dashboard = client.get("/admin", follow_redirects=False)
+    assert dashboard.status_code == 200
+
+
+def test_login_form_without_python_multipart(
+    client: "SimpleClient", monkeypatch: "pytest.MonkeyPatch"
+) -> None:
+    async def _raising_form(self: Request):  # type: ignore[override]
+        raise AssertionError("python-multipart not installed")
+
+    monkeypatch.setattr(Request, "form", _raising_form)
+
+    response = client.post(
+        "/admin/login",
+        data={"username": "admin", "password": "admin"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/admin")
 
     dashboard = client.get("/admin", follow_redirects=False)
     assert dashboard.status_code == 200

--- a/backend/tests/test_session.py
+++ b/backend/tests/test_session.py
@@ -1,0 +1,19 @@
+"""Tests for session serialization helpers."""
+
+from backend.app.session import deserialize_session, serialize_session
+
+
+def test_session_round_trip_preserves_payload() -> None:
+    payload = {"user_id": 123, "username": "alice"}
+
+    token = serialize_session(payload)
+
+    assert deserialize_session(token) == payload
+
+
+def test_tampered_session_token_is_rejected() -> None:
+    token = serialize_session({"user_id": 123})
+
+    tampered = token + "x"
+
+    assert deserialize_session(tampered) == {}


### PR DESCRIPTION
## Summary
- add a helper to parse admin login forms so they still work when python-multipart is absent
- cover the fallback behaviour and session helpers with dedicated tests

## Testing
- pytest backend/tests -q --disable-warnings

------
https://chatgpt.com/codex/tasks/task_b_68e6189ae230832fbb0babde4a56c750