### PR TITLE
Add multi-domain support and fix redirect fallbacks

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,9 @@ from .models import (
     SubdomainRedirect,
     User,
     ensure_subdomain_hits_column,
+    ensure_site_settings_domain_column,
+    ensure_short_link_domain_column,
+    ensure_subdomain_domain_column,
     ensure_user_association_columns,
     engine,
     DEFAULT_SITE_DOMAIN,
@@ -59,8 +62,10 @@ from .settings_service import (
     build_short_link_prefix,
     ensure_default_settings,
     extract_short_link,
+    get_managed_domains,
+    get_primary_domain,
     get_site_settings,
-    resolve_short_link_hosts,
+    resolve_short_link_host_map,
     update_site_settings,
 )
 from .subdomain_service import ensure_default_subdomain_blacklist
@@ -94,6 +99,7 @@ app = FastAPI(
 from .views import (  # noqa: E402  pylint: disable=wrong-import-position
     router as admin_router,
     templates as admin_templates,
+    _context_with_settings as _admin_context_with_settings,
 )
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -115,6 +121,9 @@ def ensure_tables() -> None:
         Base.metadata.create_all(bind=engine)
         ensure_subdomain_hits_column()
         ensure_user_association_columns()
+        ensure_site_settings_domain_column()
+        ensure_short_link_domain_column()
+        ensure_subdomain_domain_column()
         ensure_default_settings()
         ensure_default_admin()
         ensure_default_subdomain_blacklist()
@@ -151,13 +160,15 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
     return JSONResponse({"detail": exc.detail}, status_code=exc.status_code, headers=headers)
 
 
-def _generate_unique_code(db: Session, length: int) -> str:
+def _generate_unique_code(db: Session, length: int, domain: str) -> str:
     """生成唯一的短链接 code。"""
 
     alphabet = string.ascii_lowercase + string.digits
     for _ in range(MAX_CODE_ATTEMPTS):
         candidate = "".join(secrets.choice(alphabet) for _ in range(length))
-        exists = db.scalar(select(ShortLink).where(ShortLink.code == candidate))
+        exists = db.scalar(
+            select(ShortLink).where(ShortLink.code == candidate, ShortLink.domain == domain)
+        )
         if not exists:
             return candidate
     raise HTTPException(status.HTTP_409_CONFLICT, detail="无法生成唯一的短链接编码")
@@ -198,6 +209,19 @@ def _decode_urlencoded_form(body: bytes, charset: str = "utf-8") -> dict[str, An
     except UnicodeDecodeError as exc:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="表单内容解码失败") from exc
     return {key: value for key, value in parse_qsl(text, keep_blank_values=False)}
+
+
+def _match_managed_domain(host: str, managed_domains: list[str]) -> str | None:
+    """Return the managed domain that matches the given host."""
+
+    normalized = (host or "").strip().lower()
+    for domain in managed_domains:
+        candidate = domain.strip().lower()
+        if not candidate:
+            continue
+        if normalized == candidate or normalized.endswith(f".{candidate}"):
+            return domain
+    return None
 
 
 async def _read_form_data(request: Request, content_type: str) -> dict[str, Any]:
@@ -458,6 +482,10 @@ async def _parse_site_settings_payload(request: Request) -> SiteSettingsUpdate:
     else:
         data = await _read_form_data(request, content_type)
 
+    if "managed_domains" not in data and "site_domain" in data:
+        data["managed_domains"] = data.get("site_domain", "")
+    data.pop("site_domain", None)
+
     try:
         return SiteSettingsUpdate.model_validate(data)
     except ValidationError as exc:
@@ -665,18 +693,29 @@ async def create_short_link(
     """创建短链接，code 可空自动生成。"""
 
     settings = get_site_settings(db)
+    managed_domains = get_managed_domains(settings)
+    primary_domain = get_primary_domain(settings)
+    domain = payload.domain or primary_domain
+    if domain not in managed_domains:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="域名不在管理列表中")
+
     code = payload.code
     if code and not current_user.is_admin:
         _ensure_slug_length(code, field="短链编码")
     if code:
-        exists = db.scalar(select(ShortLink).where(ShortLink.code == code))
+        exists = db.scalar(
+            select(ShortLink).where(ShortLink.code == code, ShortLink.domain == domain)
+        )
         if exists:
             raise HTTPException(status.HTTP_409_CONFLICT, detail="短链接编码已存在")
     else:
-        code = _generate_unique_code(db, settings.short_code_length)
+        code = _generate_unique_code(db, settings.short_code_length, domain)
 
     short_link = ShortLink(
-        code=code, target_url=payload.target_url, user_id=current_user.id
+        code=code,
+        domain=domain,
+        target_url=payload.target_url,
+        user_id=current_user.id,
     )
     db.add(short_link)
     _commit_session(db, conflict_detail="短链接编码已存在")
@@ -740,14 +779,27 @@ async def update_short_link(
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="短链接不存在")
     _ensure_short_link_permission(short_link, current_user)
 
+    settings = get_site_settings(db)
+    managed_domains = get_managed_domains(settings)
+    target_domain = payload.domain or short_link.domain
+    if target_domain not in managed_domains:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="域名不在管理列表中")
+
     if payload.code != short_link.code:
         if not current_user.is_admin:
             _ensure_slug_length(payload.code, field="短链编码")
-        exists = db.scalar(select(ShortLink).where(ShortLink.code == payload.code))
+
+    if payload.code != short_link.code or target_domain != short_link.domain:
+        exists = db.scalar(
+            select(ShortLink)
+            .where(ShortLink.code == payload.code, ShortLink.domain == target_domain)
+            .where(ShortLink.id != short_link.id)
+        )
         if exists:
             raise HTTPException(status.HTTP_409_CONFLICT, detail="短链接编码已存在")
 
     short_link.code = payload.code
+    short_link.domain = target_domain
     short_link.target_url = payload.target_url
     if short_link.user_id is None:
         short_link.user_id = current_user.id
@@ -758,8 +810,16 @@ async def update_short_link(
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
         message = _feedback_html("短链已更新", tone="success")
+        context, _ = _admin_context_with_settings(request, db, current_user)
+        context.update(
+            {
+                "item": short_link,
+                "show_user_column": current_user.is_admin,
+                "oob": True,
+            }
+        )
         row_html = admin_templates.get_template("admin/partials/link_row.html").render(
-            {"request": request, "item": short_link, "oob": True}
+            context
         )
         content = f"{message}{row_html}"
         return HTMLResponse(
@@ -802,6 +862,9 @@ async def create_subdomain(
 ) -> SubdomainRedirect | HTMLResponse:
     """创建子域跳转规则，Host 为完整域名。"""
 
+    settings = get_site_settings(db)
+    managed_domains = get_managed_domains(settings)
+
     host = payload.host
     if not current_user.is_admin:
         label = extract_subdomain_label(host)
@@ -812,8 +875,13 @@ async def create_subdomain(
     if existing:
         raise HTTPException(status.HTTP_409_CONFLICT, detail="子域跳转已存在")
 
+    matched_domain = _match_managed_domain(host, managed_domains)
+    if matched_domain is None:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="域名不在管理列表中")
+
     redirect = SubdomainRedirect(
         host=host,
+        domain=matched_domain,
         target_url=payload.target_url,
         code=payload.code,
         user_id=current_user.id,
@@ -1206,6 +1274,9 @@ async def update_subdomain(
 ) -> SubdomainRedirect | HTMLResponse:
     """更新子域跳转规则。"""
 
+    settings = get_site_settings(db)
+    managed_domains = get_managed_domains(settings)
+
     redirect = db.get(SubdomainRedirect, redirect_id)
     if redirect is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="子域跳转不存在")
@@ -1224,7 +1295,12 @@ async def update_subdomain(
         if exists:
             raise HTTPException(status.HTTP_409_CONFLICT, detail="子域跳转已存在")
 
+    matched_domain = _match_managed_domain(normalized_host, managed_domains)
+    if matched_domain is None:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail="域名不在管理列表中")
+
     redirect.host = normalized_host
+    redirect.domain = matched_domain
     redirect.target_url = payload.target_url
     redirect.code = payload.code
     if redirect.user_id is None:
@@ -1236,8 +1312,16 @@ async def update_subdomain(
     hx_request = request.headers.get("hx-request") == "true"
     if hx_request:
         message = _feedback_html("子域跳转已更新", tone="success")
+        context, _ = _admin_context_with_settings(request, db, current_user)
+        context.update(
+            {
+                "item": redirect,
+                "show_user_column": current_user.is_admin,
+                "oob": True,
+            }
+        )
         row_html = admin_templates.get_template("admin/partials/subdomain_row.html").render(
-            {"request": request, "item": redirect, "oob": True}
+            context
         )
         content = f"{message}{row_html}"
         return HTMLResponse(
@@ -1262,10 +1346,13 @@ def catch_all(
     host = raw_host.split(":", 1)[0]
 
     settings = get_site_settings(db)
-    short_link_hosts = resolve_short_link_hosts(settings)
-    allow_short_link = host in short_link_hosts
+    host_map = resolve_short_link_host_map(settings)
+    allow_short_link = host in host_map
+    primary_domain = get_primary_domain(settings) or DEFAULT_SITE_DOMAIN
+    domain_for_host = host_map.get(host, primary_domain)
 
-    fallback_domain = (settings.site_domain or "").strip()
+    fallback_domain = domain_for_host if not allow_short_link else host
+    fallback_domain = fallback_domain.strip()
     if "://" in fallback_domain:
         fallback_domain = fallback_domain.split("://", 1)[1]
     fallback_domain = fallback_domain.strip("/") or DEFAULT_SITE_DOMAIN
@@ -1283,33 +1370,31 @@ def catch_all(
         match = extract_short_link(path, settings)
         if match:
             code, extra_path = match
-            short_link = db.scalar(select(ShortLink).where(ShortLink.code == code))
-            if short_link is None:
-                return RedirectResponse(
-                    fallback_url, status_code=status.HTTP_302_FOUND
-                )
+            short_link = db.scalar(
+                select(ShortLink).where(ShortLink.code == code, ShortLink.domain == domain_for_host)
+            )
+            if short_link is not None:
+                short_link.hits += 1
+                db.add(short_link)
+                _commit_session(db)
 
-            short_link.hits += 1
-            db.add(short_link)
-            _commit_session(db)
+                query = request.url.query or ""
+                target_host = _extract_host_from_url(short_link.target_url)
+                include_path = bool(extra_path) and target_host not in {"", host}
+                if include_path:
+                    destination = _compose_redirect_target(
+                        short_link.target_url,
+                        path=extra_path,
+                        query=query,
+                        include_path=True,
+                    )
+                else:
+                    destination = short_link.target_url
+                    if query:
+                        separator = "&" if "?" in destination else "?"
+                        destination = f"{destination}{separator}{query}"
 
-            query = request.url.query or ""
-            target_host = _extract_host_from_url(short_link.target_url)
-            include_path = bool(extra_path) and target_host not in {"", host}
-            if include_path:
-                destination = _compose_redirect_target(
-                    short_link.target_url,
-                    path=extra_path,
-                    query=query,
-                    include_path=True,
-                )
-            else:
-                destination = short_link.target_url
-                if query:
-                    separator = "&" if "?" in destination else "?"
-                    destination = f"{destination}{separator}{query}"
-
-            return RedirectResponse(destination, status_code=status.HTTP_302_FOUND)
+                return RedirectResponse(destination, status_code=status.HTTP_302_FOUND)
         elif settings.short_link_path != "/" and "/" not in (path or ""):
             return PlainTextResponse("Not Found", status_code=status.HTTP_404_NOT_FOUND)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -11,13 +11,22 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     String,
+    UniqueConstraint,
     create_engine,
     func,
     inspect,
+    select,
     text,
 )
 from sqlalchemy.engine import make_url
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    mapped_column,
+    relationship,
+    sessionmaker,
+)
 
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:////data/data.db")
@@ -77,6 +86,9 @@ class SiteSettings(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     site_domain: Mapped[str] = mapped_column(String(255), default=DEFAULT_SITE_DOMAIN, nullable=False)
+    managed_domains: Mapped[str] = mapped_column(
+        String(1024), default=DEFAULT_SITE_DOMAIN, nullable=False
+    )
     short_code_length: Mapped[int] = mapped_column(Integer, default=DEFAULT_SHORT_CODE_LENGTH, nullable=False)
     short_link_path: Mapped[str] = mapped_column(String(255), default=DEFAULT_SHORT_LINK_PATH, nullable=False)
     logo_url: Mapped[str] = mapped_column(String(2048), default=DEFAULT_LOGO_URL, nullable=False)
@@ -84,6 +96,11 @@ class SiteSettings(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
+
+    @property
+    def domain_list(self) -> list[str]:  # pragma: no cover - 简单访问器
+        raw = (self.managed_domains or "").split()
+        return [domain for domain in raw if domain]
 
 
 class User(Base):
@@ -113,6 +130,7 @@ class SubdomainRedirect(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     host: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    domain: Mapped[str] = mapped_column(String(255), default=DEFAULT_SITE_DOMAIN, nullable=False, index=True)
     target_url: Mapped[str] = mapped_column(String(2048))
     code: Mapped[int] = mapped_column("code_int", Integer, default=302, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -145,9 +163,13 @@ class ShortLink(Base):
     """短链接记录表。"""
 
     __tablename__ = "short_links"
+    __table_args__ = (
+        UniqueConstraint("domain", "code", name="uq_short_links_domain_code"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    code: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    domain: Mapped[str] = mapped_column(String(255), default=DEFAULT_SITE_DOMAIN, nullable=False, index=True)
+    code: Mapped[str] = mapped_column(String(64), index=True)
     target_url: Mapped[str] = mapped_column(String(2048))
     hits: Mapped[int] = mapped_column("hits_int", Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -202,4 +224,210 @@ def ensure_user_association_columns() -> None:
                     "ALTER TABLE subdomain_redirects ADD COLUMN user_id INTEGER REFERENCES users(id)"
                 )
             )
+
+
+def _fetch_primary_domain(session: Session | None = None) -> str:
+    """Read the primary managed domain from the settings table."""
+
+    def _resolve(settings: SiteSettings | None) -> str:
+        if settings is None:
+            return DEFAULT_SITE_DOMAIN
+        for candidate in (settings.managed_domains or "").split():
+            stripped = candidate.strip().lower()
+            if stripped:
+                return stripped
+        canonical = (settings.site_domain or "").strip().lower()
+        return canonical or DEFAULT_SITE_DOMAIN
+
+    if session is not None:
+        settings = session.scalar(select(SiteSettings).order_by(SiteSettings.id).limit(1))
+        return _resolve(settings)
+
+    with SessionLocal() as local:
+        settings = local.scalar(select(SiteSettings).order_by(SiteSettings.id).limit(1))
+        return _resolve(settings)
+
+
+def ensure_site_settings_domain_column() -> None:
+    """Ensure the managed_domains column exists and is populated."""
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("site_settings")}
+    if "managed_domains" in columns:
+        return
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("ALTER TABLE site_settings ADD COLUMN managed_domains VARCHAR(1024)")
+        )
+
+    with SessionLocal() as session:
+        settings_rows = session.scalars(select(SiteSettings)).all()
+        for settings in settings_rows:
+            primary = (settings.site_domain or DEFAULT_SITE_DOMAIN).strip().lower()
+            settings.managed_domains = primary or DEFAULT_SITE_DOMAIN
+            session.add(settings)
+        session.commit()
+
+
+def ensure_short_link_domain_column() -> None:
+    """Ensure short links store domain information and use scoped uniqueness."""
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("short_links")}
+    unique_constraints = inspector.get_unique_constraints("short_links")
+    has_domain_column = "domain" in columns
+    has_code_unique = any(constraint.get("column_names") == ["code"] for constraint in unique_constraints)
+
+    dialect = engine.dialect.name
+    default_domain = _fetch_primary_domain()
+
+    if dialect == "sqlite":
+        if not has_domain_column or has_code_unique:
+            with engine.begin() as connection:
+                connection.execute(text("ALTER TABLE short_links RENAME TO short_links_old"))
+                connection.execute(
+                    text(
+                        """
+                        CREATE TABLE short_links (
+                            id INTEGER NOT NULL PRIMARY KEY,
+                            domain VARCHAR(255) NOT NULL,
+                            code VARCHAR(64) NOT NULL,
+                            target_url VARCHAR(2048),
+                            hits_int INTEGER NOT NULL DEFAULT 0,
+                            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                            user_id INTEGER,
+                            CONSTRAINT uq_short_links_domain_code UNIQUE (domain, code),
+                            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE SET NULL
+                        )
+                        """
+                    )
+                )
+
+                if has_domain_column:
+                    domain_source = (
+                        "CASE WHEN COALESCE(TRIM(domain), '') = '' "
+                        "THEN :default_domain ELSE LOWER(domain) END"
+                    )
+                else:
+                    domain_source = ":default_domain"
+
+                connection.execute(
+                    text(
+                        f"""
+                        INSERT INTO short_links (id, domain, code, target_url, hits_int, created_at, user_id)
+                        SELECT
+                            id,
+                            {domain_source},
+                            code,
+                            target_url,
+                            hits_int,
+                            created_at,
+                            user_id
+                        FROM short_links_old
+                        """
+                    ),
+                    {"default_domain": default_domain},
+                )
+
+                connection.execute(text("DROP TABLE short_links_old"))
+                connection.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_short_links_domain ON short_links (domain)"
+                    )
+                )
+                connection.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_short_links_code ON short_links (code)"
+                    )
+                )
+                connection.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_short_links_user_id ON short_links (user_id)"
+                    )
+                )
+        return
+
+    if not has_domain_column:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "ALTER TABLE short_links ADD COLUMN domain VARCHAR(255)"
+                    " DEFAULT :default_domain"
+                ),
+                {"default_domain": default_domain},
+            )
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "UPDATE short_links SET domain = :default_domain "
+                    "WHERE domain IS NULL OR TRIM(domain) = ''"
+                ),
+                {"default_domain": default_domain},
+            )
+        with engine.begin() as connection:
+            connection.execute(
+                text("ALTER TABLE short_links ALTER COLUMN domain DROP DEFAULT")
+            )
+
+    if has_code_unique:
+        for constraint in unique_constraints:
+            if constraint.get("column_names") == ["code"]:
+                name = constraint.get("name")
+                if not name:
+                    continue
+                with engine.begin() as connection:
+                    connection.execute(text(f'ALTER TABLE short_links DROP CONSTRAINT "{name}"'))
+
+    constraints = inspector.get_unique_constraints("short_links")
+    has_scoped_unique = any(
+        sorted(constraint.get("column_names") or []) == ["code", "domain"]
+        for constraint in constraints
+    )
+    if not has_scoped_unique:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "ALTER TABLE short_links "
+                    "ADD CONSTRAINT uq_short_links_domain_code UNIQUE (domain, code)"
+                )
+            )
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_short_links_domain ON short_links (domain)")
+        )
+        connection.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_short_links_code ON short_links (code)")
+        )
+
+
+def ensure_subdomain_domain_column() -> None:
+    """Ensure subdomain redirects store their base domain separately."""
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("subdomain_redirects")}
+    if "domain" not in columns:
+        with engine.begin() as connection:
+            connection.execute(
+                text("ALTER TABLE subdomain_redirects ADD COLUMN domain VARCHAR(255)")
+            )
+
+        default_domain = _fetch_primary_domain()
+        with SessionLocal() as session:
+            redirects = session.scalars(select(SubdomainRedirect)).all()
+            for redirect in redirects:
+                host = (redirect.host or "").strip().lower()
+                domain = host.split(".", 1)[1] if "." in host else host
+                redirect.domain = domain or default_domain
+                session.add(redirect)
+            session.commit()
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_subdomain_redirects_domain "
+                "ON subdomain_redirects (domain)"
+            )
+        )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, ValidationInfo, field_validator
 from .models import DEFAULT_ICON_URL, DEFAULT_LOGO_URL
 from .settings_service import (
     normalize_asset_url,
+    normalize_managed_domains,
     normalize_short_code_length,
     normalize_short_link_path,
     normalize_site_domain,
@@ -43,6 +44,7 @@ class SubdomainRedirectBase(BaseModel):
 
 class SubdomainRedirect(SubdomainRedirectBase):
     id: int = Field(..., description="数据库主键")
+    domain: str = Field(..., description="所属基础域名")
     created_at: datetime = Field(..., description="创建时间")
     hits: int = Field(default=0, description="累计访问次数")
     user_id: int | None = Field(default=None, description="所属用户 ID")
@@ -94,6 +96,7 @@ class ShortLinkBase(BaseModel):
 
 class ShortLinkCreate(ShortLinkBase):
     code: str | None = Field(default=None, description="短链编码，可为空自动生成")
+    domain: str | None = Field(default=None, description="短链所属域名，可留空使用主域名")
 
     @field_validator("code")
     @classmethod
@@ -105,10 +108,21 @@ class ShortLinkCreate(ShortLinkBase):
             return None
         return normalize_slug(stripped, field="短链编码")
 
+    @field_validator("domain")
+    @classmethod
+    def _normalize_domain(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            return None
+        return normalize_site_domain(stripped)
+
 
 class ShortLink(ShortLinkBase):
     id: int = Field(..., description="数据库主键")
     code: str = Field(..., description="短链编码")
+    domain: str = Field(..., description="所属域名")
     hits: int = Field(default=0, description="访问次数")
     created_at: datetime = Field(..., description="创建时间")
     user_id: int | None = Field(default=None, description="所属用户 ID")
@@ -119,6 +133,7 @@ class ShortLink(ShortLinkBase):
 
 class ShortLinkUpdate(ShortLinkBase):
     code: str = Field(..., description="短链编码")
+    domain: str | None = Field(default=None, description="短链所属域名，可留空保留原值")
 
     @field_validator("code")
     @classmethod
@@ -127,6 +142,16 @@ class ShortLinkUpdate(ShortLinkBase):
         if not stripped:
             raise ValueError("短链编码不能为空")
         return normalize_slug(stripped, field="短链编码")
+
+    @field_validator("domain")
+    @classmethod
+    def _normalize_domain(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            return None
+        return normalize_site_domain(stripped)
 
 
 class UserBase(BaseModel):
@@ -205,16 +230,17 @@ class PasswordChange(BaseModel):
 
 
 class SiteSettingsBase(BaseModel):
-    site_domain: str = Field(..., description="基础域名，例如 yet.la")
+    managed_domains: str = Field(..., description="管理域名列表，空格分隔，首个为主域名")
     short_code_length: int = Field(..., ge=3, le=64, description="短链默认长度")
     short_link_path: str = Field(..., description="短链路径前缀，例如 / 或 /r/")
     logo_url: str = Field(..., description="LOGO 图片地址")
     icon_url: str = Field(..., description="网站 ICON 图片地址")
 
-    @field_validator("site_domain")
+    @field_validator("managed_domains")
     @classmethod
-    def _normalize_domain(cls, value: str) -> str:
-        return normalize_site_domain(value)
+    def _normalize_domains(cls, value: str) -> str:
+        domains = normalize_managed_domains(value)
+        return " ".join(domains)
 
     @field_validator("short_code_length")
     @classmethod
@@ -238,7 +264,13 @@ class SiteSettingsBase(BaseModel):
 
 
 class SiteSettings(SiteSettingsBase):
+    site_domain: str = Field(..., description="主域名")
     updated_at: datetime | None = Field(default=None, description="最近更新时间")
+
+    @field_validator("site_domain")
+    @classmethod
+    def _normalize_domain(cls, value: str) -> str:
+        return normalize_site_domain(value)
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/settings_service.py
+++ b/backend/app/settings_service.py
@@ -31,6 +31,20 @@ def normalize_site_domain(value: str | None) -> str:
     return raw or DEFAULT_SITE_DOMAIN
 
 
+def normalize_managed_domains(value: str | None) -> list[str]:
+    """Normalize a space separated list of managed domains."""
+
+    raw = (value or "").replace(",", " ")
+    domains: list[str] = []
+    for candidate in raw.split():
+        normalized = normalize_site_domain(candidate)
+        if normalized not in domains:
+            domains.append(normalized)
+    if not domains:
+        domains.append(DEFAULT_SITE_DOMAIN)
+    return domains
+
+
 def normalize_short_link_path(value: str | None) -> str:
     """Normalize the configured short link path to a canonical form."""
 
@@ -49,20 +63,40 @@ def normalize_short_link_path(value: str | None) -> str:
     return normalized
 
 
+def get_managed_domains(settings: SiteSettings) -> list[str]:
+    """Return the configured managed domains preserving order."""
+
+    domains = normalize_managed_domains(settings.managed_domains)
+    return domains
+
+
+def get_primary_domain(settings: SiteSettings) -> str:
+    """Return the primary managed domain for display and defaults."""
+
+    domains = get_managed_domains(settings)
+    return domains[0] if domains else DEFAULT_SITE_DOMAIN
+
+
+def resolve_short_link_host_map(settings: SiteSettings) -> dict[str, str]:
+    """Return a mapping of hostnames to the canonical managed domain."""
+
+    host_map: dict[str, str] = {}
+    for domain in get_managed_domains(settings):
+        canonical = domain.strip().lower()
+        if not canonical:
+            continue
+        host_map[canonical] = domain
+        if canonical.startswith("www."):
+            host_map[canonical[4:]] = domain
+        else:
+            host_map[f"www.{canonical}"] = domain
+    return {host: value for host, value in host_map.items() if host}
+
+
 def resolve_short_link_hosts(settings: SiteSettings) -> set[str]:
     """Return hostnames that should trigger short link lookups."""
 
-    canonical = (settings.site_domain or "").strip().lower()
-    if not canonical:
-        return set()
-
-    hosts = {canonical}
-    if canonical.startswith("www."):
-        hosts.add(canonical[4:])
-    else:
-        hosts.add(f"www.{canonical}")
-
-    return {host for host in hosts if host}
+    return set(resolve_short_link_host_map(settings).keys())
 
 
 def normalize_short_code_length(value: int | None) -> int:
@@ -93,8 +127,10 @@ def _default_settings_payload() -> dict[str, Any]:
         except ValueError:
             length = DEFAULT_SHORT_CODE_LENGTH
 
+    domains = normalize_managed_domains(env_domain)
     payload = {
-        "site_domain": normalize_site_domain(env_domain),
+        "site_domain": domains[0],
+        "managed_domains": " ".join(domains),
         "short_code_length": normalize_short_code_length(length),
         "short_link_path": normalize_short_link_path(env_short_path or DEFAULT_SHORT_LINK_PATH),
         "logo_url": normalize_asset_url(env_logo, DEFAULT_LOGO_URL),
@@ -121,6 +157,20 @@ def get_site_settings(db: Session) -> SiteSettings:
 
     settings = db.scalar(select(SiteSettings).order_by(SiteSettings.id).limit(1))
     if settings is not None:
+        domains = normalize_managed_domains(settings.managed_domains)
+        normalized = " ".join(domains)
+        primary = domains[0]
+        updated = False
+        if settings.managed_domains != normalized:
+            settings.managed_domains = normalized
+            updated = True
+        if settings.site_domain != primary:
+            settings.site_domain = primary
+            updated = True
+        if updated:
+            db.add(settings)
+            db.commit()
+            db.refresh(settings)
         return settings
 
     payload = _default_settings_payload()
@@ -134,7 +184,7 @@ def get_site_settings(db: Session) -> SiteSettings:
 def update_site_settings(
     db: Session,
     *,
-    site_domain: str,
+    managed_domains: str,
     short_code_length: int,
     short_link_path: str,
     logo_url: str,
@@ -143,7 +193,9 @@ def update_site_settings(
     """Persist new settings values and return the updated row."""
 
     settings = get_site_settings(db)
-    settings.site_domain = normalize_site_domain(site_domain)
+    domains = normalize_managed_domains(managed_domains)
+    settings.site_domain = domains[0]
+    settings.managed_domains = " ".join(domains)
     settings.short_code_length = normalize_short_code_length(short_code_length)
     settings.short_link_path = normalize_short_link_path(short_link_path)
     settings.logo_url = normalize_asset_url(logo_url, DEFAULT_LOGO_URL)
@@ -154,10 +206,11 @@ def update_site_settings(
     return settings
 
 
-def build_short_link_prefix(settings: SiteSettings) -> str:
+def build_short_link_prefix(settings: SiteSettings, domain: str | None = None) -> str:
     """Compose the short link prefix shown in the UI."""
 
-    domain = settings.site_domain.strip().strip("/") or DEFAULT_SITE_DOMAIN
+    effective_domain = (domain or get_primary_domain(settings)).strip().strip("/")
+    domain = effective_domain or DEFAULT_SITE_DOMAIN
     base_url = f"https://{domain}".rstrip("/")
     path = settings.short_link_path
     if not path.startswith("/"):

--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -772,8 +772,36 @@
 
       const input = group.querySelector("[data-domain-input-field]");
       const hidden = group.querySelector("[data-domain-input-hidden]");
-      const rawSuffix = group.getAttribute("data-domain-suffix") || "";
-      const suffix = rawSuffix.trim();
+      const suffixSpan = group.querySelector("[data-domain-input-suffix]");
+
+      const selectSelector = group.getAttribute("data-domain-select");
+      let select = null;
+      if (selectSelector) {
+        try {
+          select = document.querySelector(selectSelector);
+        } catch (error) {
+          select = null;
+        }
+      }
+      if (!select) {
+        const form = group.closest("form") || scope;
+        if (form instanceof Element) {
+          select = form.querySelector("[data-domain-select-source]");
+        }
+      }
+
+      const resolveSuffix = () => {
+        if (select instanceof HTMLSelectElement) {
+          const option = select.options[select.selectedIndex];
+          if (option) {
+            const suffixValue = option.getAttribute("data-domain-suffix");
+            const candidate = suffixValue || option.value || "";
+            return candidate.trim();
+          }
+        }
+        const rawSuffix = group.getAttribute("data-domain-suffix") || "";
+        return rawSuffix.trim();
+      };
 
       const updateValue = () => {
         if (!hidden) {
@@ -781,6 +809,7 @@
         }
 
         if (!input) {
+          const suffix = resolveSuffix();
           hidden.value = suffix;
           return;
         }
@@ -792,6 +821,11 @@
             input.value = normalized;
           }
           prefixValue = normalized;
+        }
+
+        const suffix = resolveSuffix();
+        if (suffixSpan instanceof HTMLElement) {
+          suffixSpan.textContent = suffix ? `.${suffix}` : "";
         }
 
         let fullValue = "";
@@ -808,6 +842,10 @@
         input.addEventListener("input", updateValue);
       }
 
+      if (select instanceof HTMLSelectElement) {
+        select.addEventListener("change", updateValue);
+      }
+
       const form = group.closest("form");
       if (form) {
         form.addEventListener("reset", () => {
@@ -818,6 +856,51 @@
       group.dataset.domainEnhanced = "true";
       group.__updateDomainValue = updateValue;
       updateValue();
+    });
+  }
+
+  function bindShortLinkDomainSelectors(root = document) {
+    const scope = root instanceof Element ? root : document;
+    const selects = scope.querySelectorAll("[data-short-link-domain]");
+
+    selects.forEach((select) => {
+      if (!(select instanceof HTMLSelectElement)) {
+        return;
+      }
+
+      if (select.dataset.shortLinkDomainEnhanced === "true") {
+        if (typeof select.__updateShortLinkPrefix === "function") {
+          select.__updateShortLinkPrefix();
+        }
+        return;
+      }
+
+      const resolveDisplayTarget = () => {
+        const selector = select.getAttribute("data-prefix-display") || "[data-short-link-prefix-display]";
+        const form = select.closest("form");
+        if (form instanceof Element) {
+          const scoped = form.querySelector(selector);
+          if (scoped) {
+            return scoped;
+          }
+        }
+        return document.querySelector(selector);
+      };
+
+      const displayTarget = resolveDisplayTarget();
+
+      const updateDisplay = () => {
+        const option = select.options[select.selectedIndex];
+        const display = option ? option.getAttribute("data-display") || option.value || "" : "";
+        if (displayTarget instanceof HTMLElement) {
+          displayTarget.textContent = display;
+        }
+      };
+
+      select.addEventListener("change", updateDisplay);
+      select.dataset.shortLinkDomainEnhanced = "true";
+      select.__updateShortLinkPrefix = updateDisplay;
+      updateDisplay();
     });
   }
 
@@ -1061,6 +1144,8 @@
       }
     });
 
+    bindShortLinkDomainSelectors(formLike);
+
     const randomInputs = formLike.querySelectorAll("[data-random-code='true']");
     randomInputs.forEach((input) => {
       if (!(input instanceof HTMLInputElement)) {
@@ -1075,6 +1160,7 @@
 
   function enhanceDynamicUI(root) {
     bindDomainInputs(root);
+    bindShortLinkDomainSelectors(root);
     bindCopyButtons(root);
     bindDetailsToggles(root);
   }

--- a/backend/app/templates/admin/index.html
+++ b/backend/app/templates/admin/index.html
@@ -84,9 +84,35 @@
             >
               <div class="theme-form__grid theme-form__grid--two-fixed">
                 <div class="theme-field">
+                  <label for="short-link-domain" class="theme-label">域名 *</label>
+                  <select
+                    id="short-link-domain"
+                    name="domain"
+                    class="theme-select"
+                    data-short-link-domain
+                    data-prefix-display="[data-short-link-prefix-display]"
+                  >
+                    {% for domain in short_link_domains %}
+                    {% set option_prefix = short_link_prefix_map.get(domain, short_link_prefix) %}
+                    {% set option_display = short_link_display_prefix_map.get(domain, short_link_display_prefix) %}
+                    <option
+                      value="{{ domain }}"
+                      data-prefix="{{ option_prefix }}"
+                      data-display="{{ option_display }}"
+                      {% if domain == primary_domain %}selected{% endif %}
+                    >
+                      {{ domain }}
+                    </option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="theme-field">
                   <label for="code" class="theme-label">短链（可改）</label>
                   <div class="theme-input-affix">
-                    <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_display_prefix }}</span>
+                    <span
+                      class="theme-input-affix__addon theme-input-affix__addon--prefix"
+                      data-short-link-prefix-display
+                    >{{ short_link_display_prefix }}</span>
                     <input
                       id="code"
                       name="code"
@@ -153,7 +179,7 @@
           <div class="theme-card__header">
             <h2 class="theme-card__title">创建子域</h2>
             <p class="theme-card__subtitle">
-              填写子域前缀即可，后缀 .{{ base_domain }} 将自动拼接；状态码默认为 302，支持在下拉菜单中切换。
+              填写子域前缀并选择域名，系统会自动拼接完整主机名；状态码默认为 302，可在下拉菜单中切换。
             </p>
           </div>
           <div class="theme-card__body">
@@ -170,11 +196,30 @@
             >
               <div class="theme-form__grid theme-form__grid--three">
                 <div class="theme-field">
+                  <label for="subdomain-domain" class="theme-label">域名 *</label>
+                  <select
+                    id="subdomain-domain"
+                    name="domain"
+                    class="theme-select"
+                    data-domain-select-source
+                  >
+                    {% for domain in managed_domains %}
+                    <option
+                      value="{{ domain }}"
+                      data-domain-suffix="{{ domain }}"
+                      {% if domain == primary_domain %}selected{% endif %}
+                    >
+                      {{ domain }}
+                    </option>
+                    {% endfor %}
+                  </select>
+                </div>
+                <div class="theme-field">
                   <label for="subdomain-prefix" class="theme-label">子域 *</label>
                   <div
                     class="theme-input-affix"
                     data-domain-input
-                    data-domain-suffix="{{ base_domain }}"
+                    data-domain-select="#subdomain-domain"
                   >
                     <input
                       id="subdomain-prefix"
@@ -188,7 +233,10 @@
                       pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
                       title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
                     />
-                    <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
+                    <span
+                      class="theme-input-affix__addon theme-input-affix__addon--suffix"
+                      data-domain-input-suffix
+                    >.{{ primary_domain }}</span>
                     <input type="hidden" name="host" data-domain-input-hidden />
                   </div>
                 </div>

--- a/backend/app/templates/admin/partials/link_edit_row.html
+++ b/backend/app/templates/admin/partials/link_edit_row.html
@@ -9,9 +9,37 @@
     >
       <div class="theme-form__grid theme-form__grid--two">
         <div class="theme-field">
+          <label for="short-link-domain-{{ item.id }}" class="theme-label">域名</label>
+          <select
+            id="short-link-domain-{{ item.id }}"
+            name="domain"
+            class="theme-select"
+            data-short-link-domain
+            data-prefix-display="[data-short-link-prefix-display-{{ item.id }}]"
+          >
+            {% set current_domain = item.domain or primary_domain %}
+            {% for domain in short_link_domains %}
+            {% set option_prefix = short_link_prefix_map.get(domain, short_link_prefix) %}
+            {% set option_display = short_link_display_prefix_map.get(domain, short_link_display_prefix) %}
+            <option
+              value="{{ domain }}"
+              data-prefix="{{ option_prefix }}"
+              data-display="{{ option_display }}"
+              {% if domain == current_domain %}selected{% endif %}
+            >
+              {{ domain }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="theme-field">
           <label for="code-{{ item.id }}" class="theme-label">短链</label>
           <div class="theme-input-affix">
-            <span class="theme-input-affix__addon theme-input-affix__addon--prefix">{{ short_link_display_prefix }}</span>
+            {% set current_prefix = short_link_display_prefix_map.get(current_domain, short_link_display_prefix) %}
+            <span
+              class="theme-input-affix__addon theme-input-affix__addon--prefix"
+              data-short-link-prefix-display-{{ item.id }}
+            >{{ current_prefix }}</span>
             <input
               id="code-{{ item.id }}"
               name="code"

--- a/backend/app/templates/admin/partials/link_row.html
+++ b/backend/app/templates/admin/partials/link_row.html
@@ -3,16 +3,18 @@
   class="theme-table__row"
   {% if oob %}hx-swap-oob="outerHTML"{% endif %}
 >
+  {% set item_prefix = short_link_prefix_map.get(item.domain, short_link_prefix) %}
+  {% set item_display_prefix = short_link_display_prefix_map.get(item.domain, short_link_display_prefix) %}
   <td class="theme-table__cell theme-table__cell--summary">
     <div class="theme-table__summary">
       <button
         type="button"
         class="theme-copy"
-        data-copy-value="{{ short_link_prefix }}{{ item.code }}"
-        aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
-        title="{{ short_link_prefix }}{{ item.code }}"
+        data-copy-value="{{ item_prefix }}{{ item.code }}"
+        aria-label="复制短链 {{ item_prefix }}{{ item.code }}"
+        title="{{ item_prefix }}{{ item.code }}"
       >
-        <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
+        <span class="theme-copy__text">{{ item_display_prefix }}{{ item.code }}</span>
         <span class="theme-copy__icon" aria-hidden="true">
           <svg viewBox="0 0 24 24">
             <rect x="9" y="9" width="12" height="12" rx="2"></rect>
@@ -74,10 +76,10 @@
             <button
               type="button"
               class="theme-copy"
-              data-copy-value="{{ short_link_prefix }}{{ item.code }}"
-              aria-label="复制短链 {{ short_link_prefix }}{{ item.code }}"
+              data-copy-value="{{ item_prefix }}{{ item.code }}"
+              aria-label="复制短链 {{ item_prefix }}{{ item.code }}"
             >
-              <span class="theme-copy__text">{{ short_link_display_prefix }}{{ item.code }}</span>
+              <span class="theme-copy__text">{{ item_display_prefix }}{{ item.code }}</span>
               <span class="theme-copy__icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24">
                   <rect x="9" y="9" width="12" height="12" rx="2"></rect>

--- a/backend/app/templates/admin/partials/settings_card.html
+++ b/backend/app/templates/admin/partials/settings_card.html
@@ -20,17 +20,17 @@
     >
       <div class="theme-form__grid theme-form__grid--two-fixed">
         <div class="theme-field theme-field--mobile-condensed">
-          <label for="site_domain" class="theme-label">管理域名 *</label>
+          <label for="managed_domains" class="theme-label">管理域名 *</label>
           <input
-            id="site_domain"
-            name="site_domain"
+            id="managed_domains"
+            name="managed_domains"
             type="text"
             required
             class="theme-input theme-input--wide"
-            placeholder="如 yet.la"
-            value="{{ site_settings.site_domain }}"
+            placeholder="如 yet.la go2.you"
+            value="{{ site_settings.managed_domains or site_settings.site_domain }}"
           />
-          <p class="theme-hint">仅输入域名，无需协议。用于限制短链入口与界面展示。</p>
+          <p class="theme-hint">空格分隔多个域名，首个为主域名。无需输入协议或路径。</p>
         </div>
         <div class="theme-field theme-field--mobile-condensed">
           <label for="short_code_length" class="theme-label">短链默认长度 *</label>

--- a/backend/app/templates/admin/partials/subdomain_edit_row.html
+++ b/backend/app/templates/admin/partials/subdomain_edit_row.html
@@ -9,29 +9,38 @@
     >
       <div class="theme-form__grid theme-form__grid--three">
         <div class="theme-field">
+          <label for="subdomain-domain-{{ item.id }}" class="theme-label">域名</label>
+          <select
+            id="subdomain-domain-{{ item.id }}"
+            class="theme-select"
+            data-domain-select-source
+          >
+            {% set current_domain = item.domain or primary_domain %}
+            {% for domain in managed_domains %}
+            <option
+              value="{{ domain }}"
+              data-domain-suffix="{{ domain }}"
+              {% if domain == current_domain %}selected{% endif %}
+            >
+              {{ domain }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="theme-field">
           <label for="host-{{ item.id }}" class="theme-label">子域</label>
-          {% set domain_suffix = '' %}
-          {% set suffix = '' %}
-          {% if base_domain %}
-          {% set suffix = '.' ~ base_domain %}
-          {% if item.host.endswith(suffix) %}
-          {% set domain_suffix = base_domain %}
-          {% endif %}
-          {% endif %}
-          {% set host_ns = namespace(value=item.host) %}
-          {% if domain_suffix %}
-          {% set host_ns.value = item.host[: item.host|length - ('.' ~ domain_suffix)|length] %}
-          {% endif %}
+          {% set host_parts = item.host.split('.', 1) %}
+          {% set host_prefix = host_parts[0] %}
           <div
             class="theme-input-affix"
             data-domain-input
-            data-domain-suffix="{{ domain_suffix }}"
+            data-domain-select="#subdomain-domain-{{ item.id }}"
           >
             <input
               id="host-{{ item.id }}"
               type="text"
               required
-              value="{{ host_ns.value }}"
+              value="{{ host_prefix }}"
               class="theme-input-affix__input"
               autocomplete="off"
               spellcheck="false"
@@ -39,7 +48,10 @@
               pattern="^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$"
               title="仅允许小写字母、数字或连字符，首尾需为字母或数字"
             />
-            <span class="theme-input-affix__addon theme-input-affix__addon--suffix">.{{ base_domain }}</span>
+            <span
+              class="theme-input-affix__addon theme-input-affix__addon--suffix"
+              data-domain-input-suffix
+            >.{{ current_domain }}</span>
             <input type="hidden" name="host" value="{{ item.host }}" data-domain-input-hidden />
           </div>
         </div>

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -28,7 +28,12 @@ from .models import (
     SubdomainRedirect,
     User,
 )
-from .settings_service import build_short_link_prefix, get_site_settings
+from .settings_service import (
+    build_short_link_prefix,
+    get_managed_domains,
+    get_primary_domain,
+    get_site_settings,
+)
 from .subdomain_service import format_blacklist_labels
 
 SUBDOMAIN_CODE_OPTIONS = [302, 301]
@@ -82,14 +87,16 @@ def _load_users(db: Session) -> list[User]:
     )
 
 
-def _generate_short_link_suggestion(db: Session, length: int) -> str:
+def _generate_short_link_suggestion(db: Session, length: int, domain: str) -> str:
     """Generate a random short link code suggestion that does not clash with existing ones."""
 
     alphabet = string.ascii_lowercase + string.digits
     attempts = max(length * 2, 10)
     for _ in range(attempts):
         candidate = "".join(secrets.choice(alphabet) for _ in range(length))
-        exists = db.scalar(select(ShortLink.id).where(ShortLink.code == candidate))
+        exists = db.scalar(
+            select(ShortLink.id).where(ShortLink.code == candidate, ShortLink.domain == domain)
+        )
         if not exists:
             return candidate
     return "".join(secrets.choice(alphabet) for _ in range(length))
@@ -98,20 +105,38 @@ def _generate_short_link_suggestion(db: Session, length: int) -> str:
 def _base_context(
     request: Request, settings: SiteSettings, user: User | None = None
 ) -> dict[str, Any]:
-    base_domain = settings.site_domain.strip().strip("/") or settings.site_domain
+    managed_domains = get_managed_domains(settings)
+    primary_domain = get_primary_domain(settings)
+    if primary_domain not in managed_domains:
+        managed_domains.insert(0, primary_domain)
+
+    prefix_map: dict[str, str] = {}
+    display_prefix_map: dict[str, str] = {}
+    for domain in managed_domains:
+        prefix = build_short_link_prefix(settings, domain)
+        display = prefix
+        for scheme in ("https://", "http://"):
+            if display.startswith(scheme):
+                display = display[len(scheme) :]
+                break
+        prefix_map[domain] = prefix
+        display_prefix_map[domain] = display
+
+    base_domain = primary_domain.strip().strip("/") or primary_domain
     base_url = f"https://{base_domain}".rstrip("/")
-    short_link_prefix = build_short_link_prefix(settings)
-    short_link_display_prefix = short_link_prefix
-    for scheme in ("https://", "http://"):
-        if short_link_display_prefix.startswith(scheme):
-            short_link_display_prefix = short_link_display_prefix[len(scheme) :]
-            break
+    short_link_prefix = prefix_map.get(primary_domain, build_short_link_prefix(settings))
+    short_link_display_prefix = display_prefix_map.get(primary_domain, short_link_prefix)
     return {
         "request": request,
         "base_domain": base_domain,
         "base_url": base_url,
         "short_link_prefix": short_link_prefix,
         "short_link_display_prefix": short_link_display_prefix,
+        "short_link_prefix_map": prefix_map,
+        "short_link_display_prefix_map": display_prefix_map,
+        "managed_domains": managed_domains,
+        "primary_domain": primary_domain,
+        "short_link_domains": managed_domains,
         "short_code_length": settings.short_code_length,
         "site_settings": settings,
         "current_year": datetime.utcnow().year,
@@ -163,6 +188,8 @@ def admin_dashboard(
     blacklist_entries = _load_subdomain_blacklist(db) if current_user.is_admin else []
 
     context, settings = _context_with_settings(request, db, current_user)
+    managed_domains = context.get("managed_domains", [])
+    primary_domain = context.get("primary_domain", settings.site_domain)
     context.update(
         {
             "active_tab": active_tab,
@@ -170,13 +197,14 @@ def admin_dashboard(
             "subdomains": subdomains,
             "users": users,
             "short_code_suggestion": _generate_short_link_suggestion(
-                db, settings.short_code_length
+                db, settings.short_code_length, primary_domain
             ),
             "subdomain_code_options": SUBDOMAIN_CODE_OPTIONS,
             "show_user_column": current_user.is_admin,
             "short_link_example": f"{context['short_link_prefix']}example",
             "subdomain_blacklist": blacklist_entries,
             "subdomain_blacklist_text": format_blacklist_labels(blacklist_entries),
+            "short_link_domains": managed_domains,
         }
     )
     if current_user.is_admin and active_tab == "settings":

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,7 +7,7 @@ def test_protected_endpoints_require_basic_auth(client: "SimpleClient") -> None:
 
     response = client.post(
         "/api/subdomains",
-        json={"host": "secure.test", "target_url": "https://example.com"},
+        json={"host": "secure.yet.la", "target_url": "https://example.com"},
     )
     assert response.status_code == 401
     assert response.headers["www-authenticate"] == "Basic"

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -6,24 +6,24 @@ ADMIN_AUTH = ("admin", "admin")
 def test_routes_endpoint_lists_subdomains(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "alpha.test", "target_url": "https://example.com/a"},
+        json={"host": "alpha.yet.la", "target_url": "https://example.com/a"},
         auth=ADMIN_AUTH,
     )
     client.post(
         "/api/subdomains",
-        json={"host": "beta.test", "target_url": "https://example.com/b"},
+        json={"host": "beta.yet.la", "target_url": "https://example.com/b"},
         auth=ADMIN_AUTH,
     )
 
     response = client.get("/routes")
     assert response.status_code == 200
     hosts = [item["host"] for item in response.json()]
-    assert hosts == ["alpha.test", "beta.test"]
+    assert hosts == ["alpha.yet.la", "beta.yet.la"]
 
 
 def test_fallback_redirect_strips_site_domain_path(client: "SimpleClient") -> None:
     settings = client.get("/api/settings", auth=ADMIN_AUTH).json()
-    settings["site_domain"] = "https://yet.la/admin"
+    settings["managed_domains"] = "https://yet.la/admin"
     client.put("/api/settings", json=settings, auth=ADMIN_AUTH)
 
     response = client.get("/foo/bar", headers={"host": "yet.la"}, follow_redirects=False)
@@ -35,7 +35,7 @@ def test_fallback_redirect_uses_request_host_for_short_links(
     client: "SimpleClient",
 ) -> None:
     settings = client.get("/api/settings", auth=ADMIN_AUTH).json()
-    settings["site_domain"] = "https://www.example.com"
+    settings["managed_domains"] = "https://www.example.com"
     client.put("/api/settings", json=settings, auth=ADMIN_AUTH)
 
     response = client.get("/missing", headers={"host": "example.com"}, follow_redirects=False)
@@ -47,7 +47,7 @@ def test_missing_short_link_with_nested_path_redirects_to_root(
     client: "SimpleClient",
 ) -> None:
     settings = client.get("/api/settings", auth=ADMIN_AUTH).json()
-    settings["site_domain"] = "https://yet.la"
+    settings["managed_domains"] = "https://yet.la"
     client.put("/api/settings", json=settings, auth=ADMIN_AUTH)
 
     response = client.get(

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -9,7 +9,7 @@ def test_settings_requires_admin(client: "SimpleClient") -> None:
 
 def test_update_settings_affects_short_links(client: "SimpleClient") -> None:
     payload = {
-        "site_domain": "https://Example.COM",
+        "managed_domains": "https://Example.COM blog.example",
         "short_code_length": "4",
         "short_link_path": "r",
         "logo_url": "https://cdn.example.com/logo.png",
@@ -25,6 +25,7 @@ def test_update_settings_affects_short_links(client: "SimpleClient") -> None:
     assert update.status_code == 200
     body = update.json()
     assert body["site_domain"] == "example.com"
+    assert body["managed_domains"] == "example.com blog.example"
     assert body["short_code_length"] == 4
     assert body["short_link_path"] == "/r/"
     assert body["logo_url"] == payload["logo_url"]
@@ -34,6 +35,7 @@ def test_update_settings_affects_short_links(client: "SimpleClient") -> None:
     assert fetched.status_code == 200
     fetched_body = fetched.json()
     assert fetched_body["site_domain"] == "example.com"
+    assert fetched_body["managed_domains"] == "example.com blog.example"
     assert fetched_body["short_link_path"] == "/r/"
 
     create_response = client.post(
@@ -53,7 +55,7 @@ def test_update_settings_affects_short_links(client: "SimpleClient") -> None:
 
 def test_update_settings_via_htmx_returns_partial(client: "SimpleClient") -> None:
     payload = {
-        "site_domain": "yet.la",
+        "managed_domains": "yet.la",
         "short_code_length": "6",
         "short_link_path": "/a/",
         "logo_url": "https://cdn.example.com/logo-alt.png",

--- a/backend/tests/test_short_links.py
+++ b/backend/tests/test_short_links.py
@@ -14,6 +14,7 @@ def test_create_short_link(client: "SimpleClient") -> None:
     assert payload["target_url"] == "https://example.com"
     assert payload["code"]
     assert payload["hits"] == 0
+    assert payload["domain"] == "yet.la"
 
 
 def test_create_short_link_conflict(client: "SimpleClient") -> None:
@@ -30,6 +31,40 @@ def test_create_short_link_conflict(client: "SimpleClient") -> None:
     )
     assert conflict.status_code == 409
     assert conflict.json() == {"error": "短链接编码已存在"}
+
+
+def test_create_short_link_allows_same_code_different_domain(client: "SimpleClient") -> None:
+    original = client.get("/api/settings", auth=ADMIN_AUTH).json()
+
+    update = client.put(
+        "/api/settings",
+        data={
+            "managed_domains": "yet.la go2.you",
+            "short_code_length": "6",
+            "short_link_path": "/",
+            "logo_url": "https://img.example.com/logo.png",
+            "icon_url": "https://img.example.com/icon.png",
+        },
+        auth=ADMIN_AUTH,
+    )
+    assert update.status_code == 200
+
+    first = client.post(
+        "/api/links",
+        json={"target_url": "https://example.com", "code": "dup", "domain": "yet.la"},
+        auth=ADMIN_AUTH,
+    )
+    assert first.status_code == 201
+    second = client.post(
+        "/api/links",
+        json={"target_url": "https://example.org", "code": "dup", "domain": "go2.you"},
+        auth=ADMIN_AUTH,
+    )
+    assert second.status_code == 201
+    assert first.json()["domain"] == "yet.la"
+    assert second.json()["domain"] == "go2.you"
+
+    client.put("/api/settings", json=original, auth=ADMIN_AUTH)
 
 
 def test_create_short_link_invalid_code(client: "SimpleClient") -> None:
@@ -133,7 +168,7 @@ def test_redirect_short_link_with_admin_prefix(client: "SimpleClient") -> None:
     update = client.put(
         "/api/settings",
         data={
-            "site_domain": "yet.la",
+            "managed_domains": "yet.la",
             "short_code_length": "6",
             "short_link_path": "/admin/",
             "logo_url": "https://img.example.com/logo.png",
@@ -197,7 +232,7 @@ def test_missing_short_link_with_path_avoids_subdomain_loop(
     update = client.put(
         "/api/settings",
         data={
-            "site_domain": "https://www.example.com",
+            "managed_domains": "https://www.example.com",
             "short_code_length": "6",
             "short_link_path": "/g/",
             "logo_url": "https://img.example.com/logo.png",

--- a/backend/tests/test_subdomains.py
+++ b/backend/tests/test_subdomains.py
@@ -6,27 +6,28 @@ ADMIN_AUTH = ("admin", "admin")
 def test_create_subdomain(client: "SimpleClient") -> None:
     response = client.post(
         "/api/subdomains",
-        json={"host": "docs.test", "target_url": "https://example.com/docs", "code": 301},
+        json={"host": "docs.yet.la", "target_url": "https://example.com/docs", "code": 301},
         auth=ADMIN_AUTH,
     )
     assert response.status_code == 201
     payload = response.json()
-    assert payload["host"] == "docs.test"
+    assert payload["host"] == "docs.yet.la"
     assert payload["target_url"] == "https://example.com/docs"
     assert payload["code"] == 301
     assert payload["hits"] == 0
+    assert payload["domain"] == "yet.la"
 
 
 def test_create_subdomain_conflict(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "api.test", "target_url": "https://example.com/api"},
+        json={"host": "api.yet.la", "target_url": "https://example.com/api"},
         auth=ADMIN_AUTH,
     )
 
     conflict = client.post(
         "/api/subdomains",
-        json={"host": "api.test", "target_url": "https://example.org/api"},
+        json={"host": "api.yet.la", "target_url": "https://example.org/api"},
         auth=ADMIN_AUTH,
     )
     assert conflict.status_code == 409
@@ -36,7 +37,7 @@ def test_create_subdomain_conflict(client: "SimpleClient") -> None:
 def test_create_subdomain_invalid_prefix(client: "SimpleClient") -> None:
     response = client.post(
         "/api/subdomains",
-        json={"host": "-bad.test", "target_url": "https://example.com/bad"},
+        json={"host": "-bad.yet.la", "target_url": "https://example.com/bad"},
         auth=ADMIN_AUTH,
     )
     assert response.status_code == 422
@@ -47,14 +48,14 @@ def test_create_subdomain_invalid_prefix(client: "SimpleClient") -> None:
 def test_delete_subdomain(client: "SimpleClient") -> None:
     created = client.post(
         "/api/subdomains",
-        json={"host": "remove.test", "target_url": "https://example.com/remove"},
+        json={"host": "remove.yet.la", "target_url": "https://example.com/remove"},
         auth=ADMIN_AUTH,
     ).json()
 
     deleted = client.delete(f"/api/subdomains/{created['id']}", auth=ADMIN_AUTH)
     assert deleted.status_code == 204
 
-    fallback = client.get("/", headers={"host": "remove.test"}, follow_redirects=False)
+    fallback = client.get("/", headers={"host": "remove.yet.la"}, follow_redirects=False)
     assert fallback.status_code == 302
     assert fallback.headers["location"] == "https://yet.la"
 
@@ -62,13 +63,13 @@ def test_delete_subdomain(client: "SimpleClient") -> None:
 def test_update_subdomain_via_htmx_form(client: "SimpleClient") -> None:
     created = client.post(
         "/api/subdomains",
-        json={"host": "edit.test", "target_url": "https://example.com/old"},
+        json={"host": "edit.yet.la", "target_url": "https://example.com/old"},
         auth=ADMIN_AUTH,
     ).json()
 
     response = client.put(
         f"/api/subdomains/{created['id']}",
-        data={"host": "edit.test", "target_url": "https://example.com/new", "code": "301"},
+        data={"host": "edit.yet.la", "target_url": "https://example.com/new", "code": "301"},
         headers={"hx-request": "true"},
         auth=ADMIN_AUTH,
     )
@@ -103,7 +104,7 @@ def test_subdomain_blacklist_blocks_creation(client: "SimpleClient") -> None:
 
     denied = client.post(
         "/api/subdomains",
-        json={"host": "blocked.test", "target_url": "https://example.com/blocked"},
+        json={"host": "blocked.yet.la", "target_url": "https://example.com/blocked"},
         auth=user_auth,
     )
     assert denied.status_code == 422
@@ -111,7 +112,7 @@ def test_subdomain_blacklist_blocks_creation(client: "SimpleClient") -> None:
 
     allowed = client.post(
         "/api/subdomains",
-        json={"host": "blocked.test", "target_url": "https://example.com/allowed"},
+        json={"host": "blocked.yet.la", "target_url": "https://example.com/allowed"},
         auth=ADMIN_AUTH,
     )
     assert allowed.status_code == 201
@@ -145,7 +146,7 @@ def test_subdomain_blacklist_blocks_updates(client: "SimpleClient") -> None:
 
     redirect = client.post(
         "/api/subdomains",
-        json={"host": "safe.test", "target_url": "https://example.com/safe"},
+        json={"host": "safe.yet.la", "target_url": "https://example.com/safe"},
         auth=owner_auth,
     ).json()
 
@@ -157,7 +158,7 @@ def test_subdomain_blacklist_blocks_updates(client: "SimpleClient") -> None:
 
     response = client.put(
         f"/api/subdomains/{redirect['id']}",
-        json={"host": "blocked.test", "target_url": "https://example.com/new", "code": 302},
+        json={"host": "blocked.yet.la", "target_url": "https://example.com/new", "code": 302},
         auth=owner_auth,
     )
     assert response.status_code == 422
@@ -165,11 +166,11 @@ def test_subdomain_blacklist_blocks_updates(client: "SimpleClient") -> None:
 
     admin_update = client.put(
         f"/api/subdomains/{redirect['id']}",
-        json={"host": "blocked.test", "target_url": "https://example.com/new", "code": 302},
+        json={"host": "blocked.yet.la", "target_url": "https://example.com/new", "code": 302},
         auth=ADMIN_AUTH,
     )
     assert admin_update.status_code == 200
-    assert admin_update.json()["host"] == "blocked.test"
+    assert admin_update.json()["host"] == "blocked.yet.la"
 
     blacklist_listing = client.get("/api/subdomain-blacklist", auth=ADMIN_AUTH).json()
     blocked_entry = next(item for item in blacklist_listing if item["label"] == "blocked")
@@ -193,7 +194,7 @@ def test_non_admin_subdomain_length_enforced(client: "SimpleClient") -> None:
 
     denied = client.post(
         "/api/subdomains",
-        json={"host": "xy.test", "target_url": "https://example.com/too-short"},
+        json={"host": "xy.yet.la", "target_url": "https://example.com/too-short"},
         auth=user_auth,
     )
     assert denied.status_code == 422
@@ -203,12 +204,12 @@ def test_non_admin_subdomain_length_enforced(client: "SimpleClient") -> None:
 def test_admin_allows_short_subdomain_prefix(client: "SimpleClient") -> None:
     response = client.post(
         "/api/subdomains",
-        json={"host": "xy.test", "target_url": "https://example.com/admin"},
+        json={"host": "xy.yet.la", "target_url": "https://example.com/admin"},
         auth=ADMIN_AUTH,
     )
     assert response.status_code == 201
     created = response.json()
-    assert created["host"] == "xy.test"
+    assert created["host"] == "xy.yet.la"
 
     client.delete(f"/api/subdomains/{created['id']}", auth=ADMIN_AUTH)
 
@@ -245,23 +246,23 @@ def test_admin_can_replace_subdomain_blacklist(client: "SimpleClient") -> None:
 def test_host_redirect_status_codes(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "legacy.test", "target_url": "https://legacy.example.com", "code": 301},
+        json={"host": "legacy.yet.la", "target_url": "https://legacy.example.com", "code": 301},
         auth=ADMIN_AUTH,
     )
     client.post(
         "/api/subdomains",
-        json={"host": "www.test", "target_url": "https://www.example.com"},
+        json={"host": "www.yet.la", "target_url": "https://www.example.com"},
         auth=ADMIN_AUTH,
     )
 
     permanent = client.get(
-        "/path", headers={"host": "legacy.test"}, follow_redirects=False
+        "/path", headers={"host": "legacy.yet.la"}, follow_redirects=False
     )
     assert permanent.status_code == 301
     assert permanent.headers["location"] == "https://legacy.example.com/path"
 
     temporary = client.get(
-        "/docs?id=1", headers={"host": "www.test"}, follow_redirects=False
+        "/docs?id=1", headers={"host": "www.yet.la"}, follow_redirects=False
     )
     assert temporary.status_code == 302
     assert (
@@ -273,14 +274,14 @@ def test_host_redirect_status_codes(client: "SimpleClient") -> None:
 def test_subdomain_redirect_increments_hits(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "count.test", "target_url": "https://example.com/hits"},
+        json={"host": "count.yet.la", "target_url": "https://example.com/hits"},
         auth=ADMIN_AUTH,
     )
 
     for _ in range(3):
         response = client.get(
             "/path",
-            headers={"host": "count.test"},
+            headers={"host": "count.yet.la"},
             follow_redirects=False,
         )
         assert response.status_code == 302
@@ -294,20 +295,20 @@ def test_subdomain_redirect_increments_hits(client: "SimpleClient") -> None:
 def test_permanent_redirect_counts_hits(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "permanent.test", "target_url": "https://example.com/permanent", "code": 301},
+        json={"host": "permanent.yet.la", "target_url": "https://example.com/permanent", "code": 301},
         auth=ADMIN_AUTH,
     )
 
     response = client.get(
         "/docs",
-        headers={"host": "permanent.test"},
+        headers={"host": "permanent.yet.la"},
         follow_redirects=False,
     )
     assert response.status_code == 301
 
     listing = client.get("/api/subdomains", auth=ADMIN_AUTH)
     assert listing.status_code == 200
-    record = next(item for item in listing.json() if item["host"] == "permanent.test")
+    record = next(item for item in listing.json() if item["host"] == "permanent.yet.la")
     assert record["hits"] == 1
 
 
@@ -320,7 +321,7 @@ def test_host_redirect_not_found(client: "SimpleClient") -> None:
 def test_admin_subdomain_table_includes_user_column(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "table.test", "target_url": "https://example.com"},
+        json={"host": "table.yet.la", "target_url": "https://example.com"},
         auth=ADMIN_AUTH,
     )
 
@@ -332,7 +333,7 @@ def test_admin_subdomain_table_includes_user_column(client: "SimpleClient") -> N
 def test_subdomains_are_scoped_by_user(client: "SimpleClient") -> None:
     client.post(
         "/api/subdomains",
-        json={"host": "admin-only.test", "target_url": "https://admin.example.com"},
+        json={"host": "admin-only.yet.la", "target_url": "https://admin.example.com"},
         auth=ADMIN_AUTH,
     )
 
@@ -350,7 +351,7 @@ def test_subdomains_are_scoped_by_user(client: "SimpleClient") -> None:
     user_auth = ("charlie", "charliepw")
     client.post(
         "/api/subdomains",
-        json={"host": "member.test", "target_url": "https://user.example.com"},
+        json={"host": "member.yet.la", "target_url": "https://user.example.com"},
         auth=user_auth,
     )
 
@@ -358,17 +359,17 @@ def test_subdomains_are_scoped_by_user(client: "SimpleClient") -> None:
     assert user_listing.status_code == 200
     user_records = user_listing.json()
     assert len(user_records) == 1
-    assert user_records[0]["host"] == "member.test"
+    assert user_records[0]["host"] == "member.yet.la"
 
     admin_listing = client.get("/api/subdomains", auth=ADMIN_AUTH)
     admin_hosts = {record["host"] for record in admin_listing.json()}
-    assert admin_hosts == {"admin-only.test", "member.test"}
+    assert admin_hosts == {"admin-only.yet.la", "member.yet.la"}
 
 
 def test_non_admin_cannot_modify_other_subdomains(client: "SimpleClient") -> None:
     admin_redirect = client.post(
         "/api/subdomains",
-        json={"host": "lock.test", "target_url": "https://secure.example.com"},
+        json={"host": "lock.yet.la", "target_url": "https://secure.example.com"},
         auth=ADMIN_AUTH,
     ).json()
 
@@ -394,7 +395,7 @@ def test_non_admin_cannot_modify_other_subdomains(client: "SimpleClient") -> Non
 
     forbidden_update = client.put(
         f"/api/subdomains/{admin_redirect['id']}",
-        json={"host": "lock.test", "target_url": "https://evil.example.com", "code": 302},
+        json={"host": "lock.yet.la", "target_url": "https://evil.example.com", "code": 302},
         auth=user_auth,
     )
     assert forbidden_update.status_code == 403


### PR DESCRIPTION
## Summary
- add managed domain support across models, services, and API routes so short links and subdomains are scoped per domain
- update the admin UI and HTMX partials to surface domain selection and include domain-aware context for refreshes
- refine redirect fallback logic to honor subdomain mappings when no short link is found

## Testing
- pytest backend/tests/test_short_links.py backend/tests/test_subdomains.py backend/tests/test_routes.py backend/tests/test_settings.py

------
https://chatgpt.com/codex/tasks/task_b_68e62bb5afb4832fafd1d45c771da347