### PR TITLE
fix: redirect go2.you apex to www

### DIFF
--- a/infra/nginx/conf.d/subdomains.conf
+++ b/infra/nginx/conf.d/subdomains.conf
@@ -18,16 +18,21 @@ map $host $target_upstream {
     default app_default;
     ~^api\.yet\.la$ app_api;
     ~^console\.yet\.la$ app_console;
+    ~^(www\.)?go2\.you$ app_default;
 }
 
 # 主服务器块捕获所有 yet.la 的子域请求。
 server {
     listen 80;
-    server_name .yet.la yet.la;
+    server_name .yet.la yet.la .go2.you go2.you;
 
     # 对静态站点的示例跳转，可根据需求选择 301/302。
     if ($host = console.yet.la) {
         return 302 https://console.yet.la$request_uri;
+    }
+
+    if ($host = go2.you) {
+        return 301 https://www.go2.you$request_uri;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- map go2.you hosts to the default upstream in the subdomain router
- include go2.you in the server block and redirect apex traffic to www.go2.you

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_b_68e644f5c84c832f94945c6d6c0c875a