### PR TITLE
Update Nginx domain routing for www redirects

### DIFF
--- a/infra/nginx/conf.d/subdomains.conf
+++ b/infra/nginx/conf.d/subdomains.conf
@@ -1,44 +1,52 @@
-# Yetla Nginx 配置示例：根据子域名路由到不同的 upstream。
+# Yetla Nginx 配置示例：根据域名路由到默认 upstream，并为裸域名跳转到 www 子域。
 
-# 定义静态 upstream。生产环境可改为指向真实服务或容器。
-upstream app_api {
-    server app_api:80;
-}
-
-upstream app_console {
-    server app_console:80;
-}
-
+# 定义默认 upstream。生产环境可改为指向真实服务或容器。
 upstream app_default {
     server app_default:80;
 }
 
-# 通过 map 指令将 Host 头映射到对应的 upstream。
-map $host $target_upstream {
-    default app_default;
-    ~^api\.yet\.la$ app_api;
-    ~^console\.yet\.la$ app_console;
-}
-
-# 主服务器块捕获所有 yet.la 的子域请求。
+# 将裸域名统一重定向到对应的 www 子域。
 server {
     listen 80;
-    server_name .yet.la yet.la;
+    server_name yet.la go2.you;
 
-    # 对静态站点的示例跳转，可根据需求选择 301/302。
-    if ($host = console.yet.la) {
-        return 302 https://console.yet.la$request_uri;
-    }
+    return 301 https://www.$host$request_uri;
+}
+
+# 处理 www.yet.la 请求。
+server {
+    listen 80;
+    server_name www.yet.la;
 
     location / {
-        proxy_pass http://$target_upstream;
+        proxy_pass http://app_default;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # 可选：为根域提供静态兜底页面
+    # 可选：为站点提供静态兜底页面
+    location @fallback_static {
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+    }
+}
+
+# 处理 www.go2.you 请求。
+server {
+    listen 80;
+    server_name www.go2.you;
+
+    location / {
+        proxy_pass http://app_default;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 可选：为站点提供静态兜底页面
     location @fallback_static {
         root /usr/share/nginx/html;
         try_files /index.html =404;


### PR DESCRIPTION
## Summary
- simplify the subdomain configuration to only use the default upstream
- redirect bare yet.la and go2.you domains to their www subdomains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e6474fad84832fb4e3c2f6b16d9ab6