### PR TITLE
Fix HTTPS handling for go2.you domain

### DIFF
--- a/infra/nginx/conf.d/yetla.upstream.conf
+++ b/infra/nginx/conf.d/yetla.upstream.conf
@@ -8,7 +8,7 @@ upstream backend_app {
 server {
     listen 80;
     listen [::]:80;
-    server_name yet.la *.yet.la;
+    server_name yet.la *.yet.la go2.you *.go2.you;
 
     return 301 https://$host$request_uri;
 }
@@ -16,7 +16,7 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name yet.la *.yet.la;
+    server_name yet.la *.yet.la *.go2.you;
 
     ssl_certificate /etc/nginx/ssl/fullchain.cer;
     ssl_certificate_key /etc/nginx/ssl/private.key;
@@ -46,4 +46,20 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
     }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name go2.you;
+
+    ssl_certificate /etc/nginx/ssl/fullchain.cer;
+    ssl_certificate_key /etc/nginx/ssl/private.key;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    return 301 https://www.$host$request_uri;
 }


### PR DESCRIPTION
## Summary
- include go2.you in the HTTPS server blocks so requests serve the application
- add an explicit TLS redirect from https://go2.you to https://www.go2.you to avoid 404 responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e64be9e948832f9148d8c473b20e51