### PR TITLE
Rename yetla project to SubLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-本文件用于记录 yet.la 管理平台的变更。以下条目初始化了「服务端重定向」基线任务，方便后续迭代追踪。
+本文件用于记录 SubLink（yet.la）管理平台的变更。以下条目初始化了「服务端重定向」基线任务，方便后续迭代追踪。
 
 ## [v1.10.8.3] - 2025-10-15
 
@@ -46,7 +46,7 @@
 - README 新增「一键命令」章节，介绍上述快捷指令。
 
 ### 2025-10-06
-- 新增 `infra/nginx/conf.d/yetla.upstream.conf`，将容器内 Nginx 的入口统一代理到 `backend`。
+- 新增 `infra/nginx/conf.d/sublink.upstream.conf`，将容器内 Nginx 的入口统一代理到 `backend`。
 - 提供 `docker-compose.override.yml`，默认保留 `8080:80` 并可选开启 `80:80` 暴露端口。
 - README 补充部署章节，说明容器化 Nginx → backend 的统一流量入口。
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# yet.la 管理平台
+# SubLink 短链子域管理平台
 
-自托管的 yet.la 域名跳转管理平台，提供受 HTTP Basic 保护的管理后台与 API，用于维护子域名路由与短链接。Cloudflare 负责 DNS 与 TLS
+SubLink 是 yet.la 域名的自托管短链与子域跳转管理平台，提供受 HTTP Basic 保护的管理后台与 API，用于维护二级域路由与短链接。Cloudflare 负责 DNS 与 TLS
 终止，Nginx 统一接受公网流量并转发到 FastAPI 后端。
+
+> Open Source Short-Link & Domain Routing System
 
 > 当前版本：**v1.10.8.3** —— 文档现已详细说明多域名治理策略，明确首个域名即平台主域名，用于默认短链与品牌展示；其余域名可供跳转使用，但对外展示的域名文案始终来源于该主域，避免出现多个对外标识。
 
@@ -28,7 +30,7 @@
 
 ## 本仓库包含什么？
 
-> ✅ 当前版本提供一套可直接部署的 HTTPS 反向代理 + FastAPI 管理后端，覆盖 yet.la 全域的短链接与子域跳转管理需求。
+> ✅ SubLink 当前版本提供一套可直接部署的 HTTPS 反向代理 + FastAPI 管理后端，覆盖 yet.la 全域的短链接与子域跳转管理需求。
 
 ```
 .
@@ -42,7 +44,7 @@
 └── scripts/               # 自动化脚本（如备份、冒烟测试）
 ```
 
-- **统一反向代理**：`infra/nginx/conf.d/yetla.upstream.conf` 监听 `80/443`，负责 HTTP→HTTPS 重定向与上游代理。
+- **统一反向代理**：`infra/nginx/conf.d/sublink.upstream.conf` 监听 `80/443`，负责 HTTP→HTTPS 重定向与上游代理。
 - **认证后台 + API**：`backend/app/main.py` 提供 HTMX 管理界面及 REST API，所有写操作需登录（支持 HTTP Basic 或后台表单）。
 - **多用户权限管理**：`backend/app/models.py` 中新增 `users` 表，支持区分管理员与普通用户，并在后台界面完成用户 CRUD 与密码管理。
 - **子域屏蔽名单管控**：`backend/app/subdomain_service.py` 会在启动时写入默认的保留前缀列表，并通过 `/api/subdomain-blacklist` 提供增删改查接口，管理员可自定义限制普通用户可用的子域。
@@ -62,8 +64,8 @@
 
 ```bash
 # 1. 克隆仓库
-$ git clone git@github.com:your-org/yetla.git
-$ cd yetla
+$ git clone git@github.com:your-org/sublink.git
+$ cd sublink
 
 # 2. 启动容器（首次部署建议重新构建镜像）
 $ docker compose up -d --build
@@ -156,8 +158,8 @@ curl -sk -u admin:admin \
    ```
 2. **克隆仓库并进入项目目录**
    ```bash
-   git clone https://github.com/your-org/yetla.git
-   cd yetla
+   git clone https://github.com/your-org/sublink.git
+   cd sublink
    ```
 3. **安装运行依赖（Docker、Docker Compose 插件）**
    - 推荐执行仓库脚本：
@@ -213,7 +215,7 @@ Nginx 容器通过只读挂载 `/root/ssl -> /etc/nginx/ssl-src` 读取证书，
 3. `docker-compose.yml` 将 `/root/ssl` 以只读方式挂载到容器 `/etc/nginx/ssl-src`，并在容器内部创建独立的数据卷 `/etc/nginx/ssl`。入口脚本会自动在可写目录下生成 `fullchain.cer` 与 `private.key` 的符号链接，支持常见的 `*.cer/.pem` 命名。
 4. 如需轮换证书，先更新宿主机指向的目标文件，再执行 `docker compose restart nginx` 触发入口脚本重新链接。
 
-`infra/nginx/conf.d/yetla.upstream.conf` 的核心配置片段如下：
+`infra/nginx/conf.d/sublink.upstream.conf` 的核心配置片段如下：
 
 ```nginx
 server {

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
-# Yetla Backend
+# SubLink Backend
 
-`backend/` 目录包含 Yetla 平台的核心 FastAPI 服务，负责：
+`backend/` 目录包含 SubLink 平台的核心 FastAPI 服务，负责：
 
 - 提供受 HTTP Basic 保护的管理后台（基于 HTMX）和 REST API；
 - 维护短链接与子域跳转的数据库模型，并统计命中次数；

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,1 @@
-"""Backend package for the yet.la management platform."""
+"""Backend package for the SubLink (yet.la) management platform."""

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,4 +1,4 @@
-"""Backend package for yetla prototype."""
+"""Backend package for the SubLink prototype."""
 
 from .main import app
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-"""FastAPI 应用，提供 yet.la 的短链接与子域跳转管理接口。"""
+"""FastAPI 应用，提供 SubLink（yet.la）的短链接与子域跳转管理接口。"""
 from __future__ import annotations
 
 import secrets
@@ -88,7 +88,7 @@ def _feedback_html(message: str, *, tone: str = "info") -> str:
     return f'<div class="theme-feedback__message {tone_class}">{message}</div>'
 
 app = FastAPI(
-    title="Yetla Redirect API",
+    title="SubLink Redirect API",
     description="管理短链接与子域跳转的受保护接口，并提供公共重定向入口。",
     version="0.2.0",
     docs_url=None,

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -11,8 +11,8 @@ from typing import Any
 
 from fastapi import Request, Response
 
-SESSION_COOKIE_NAME = "yetla_session"
-_SESSION_SECRET = os.getenv("SESSION_SECRET", os.getenv("ADMIN_PASS", "yetla-session")).encode("utf-8")
+SESSION_COOKIE_NAME = "sublink_session"
+_SESSION_SECRET = os.getenv("SESSION_SECRET", os.getenv("ADMIN_PASS", "sublink-session")).encode("utf-8")
 
 
 def _b64encode(data: bytes) -> str:
@@ -53,16 +53,16 @@ def deserialize_session(token: str | None) -> dict[str, Any]:
 
 
 def get_session(request: Request) -> dict[str, Any]:
-    cached = getattr(request.state, "_yetla_session", None)
+    cached = getattr(request.state, "_sublink_session", None)
     if cached is not None:
         return cached
     session = deserialize_session(request.cookies.get(SESSION_COOKIE_NAME))
-    request.state._yetla_session = session
+    request.state._sublink_session = session
     return session
 
 
 def set_session(response: Response, request: Request, data: dict[str, Any]) -> None:
-    request.state._yetla_session = data
+    request.state._sublink_session = data
     response.set_cookie(
         SESSION_COOKIE_NAME,
         serialize_session(data),
@@ -73,7 +73,7 @@ def set_session(response: Response, request: Request, data: dict[str, Any]) -> N
 
 
 def clear_session(response: Response, request: Request) -> None:
-    request.state._yetla_session = {}
+    request.state._sublink_session = {}
     response.delete_cookie(
         SESSION_COOKIE_NAME,
         path="/",

--- a/backend/app/static/admin-dashboard.js
+++ b/backend/app/static/admin-dashboard.js
@@ -1,5 +1,5 @@
 (function () {
-  const THEME_STORAGE_KEY = "yetla-admin-theme";
+  const THEME_STORAGE_KEY = "sublink-admin-theme";
   const AVAILABLE_THEMES = ["aurora", "nebula"];
   const DEFAULT_THEME = "aurora";
   const RANDOM_CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -1167,7 +1167,7 @@
 
   onReady(() => {
     const useFallback =
-      !window.htmx || window.htmx.__YETLA_USE_FALLBACK__ === true;
+      !window.htmx || window.htmx.__SUBLINK_USE_FALLBACK__ === true;
 
     if (
       useFallback &&

--- a/backend/app/static/vendor/htmx-lite.js
+++ b/backend/app/static/vendor/htmx-lite.js
@@ -3,7 +3,7 @@
     return;
   }
 
-  if (window.htmx && window.htmx.__YETLA_USE_FALLBACK__ !== true) {
+  if (window.htmx && window.htmx.__SUBLINK_USE_FALLBACK__ !== true) {
     return;
   }
 
@@ -54,7 +54,7 @@
     config: {
       useFallback: true,
     },
-    __YETLA_USE_FALLBACK__: true,
+    __SUBLINK_USE_FALLBACK__: true,
     trigger,
     onLoad,
     off: function () {},

--- a/backend/app/templates/base.html
+++ b/backend/app/templates/base.html
@@ -17,7 +17,7 @@
         var supported = ["aurora", "nebula"];
         try {
           if (typeof window !== "undefined" && window.localStorage) {
-            var stored = window.localStorage.getItem("yetla-admin-theme");
+            var stored = window.localStorage.getItem("sublink-admin-theme");
             if (stored && supported.indexOf(stored) !== -1) {
               fallback = stored;
             }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./infra/nginx/conf.d/yetla.upstream.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/nginx/conf.d/sublink.upstream.conf:/etc/nginx/conf.d/default.conf:ro
 
   backend:
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./infra/nginx/conf.d/yetla.upstream.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./infra/nginx/conf.d/sublink.upstream.conf:/etc/nginx/conf.d/default.conf:ro
       - ./infra/nginx/docker-entrypoint.d:/docker-entrypoint.d:ro
       - type: bind
         source: /root/ssl

--- a/docs/NGINX_SUBDOMAIN_ROUTING.md
+++ b/docs/NGINX_SUBDOMAIN_ROUTING.md
@@ -1,6 +1,6 @@
 # 使用 Nginx 管理二级域名跳转的可行性
 
-当所有二级域名都解析到同一台入口服务器时，可以通过 Nginx 的反向代理能力实现基于 `Host` 的动态路由，无需频繁调整 DNS 记录。Yetla 在此基础上进一步引入数据库驱动的规则管理，使得入口层不必重载即可新增/修改跳转。
+当所有二级域名都解析到同一台入口服务器时，可以通过 Nginx 的反向代理能力实现基于 `Host` 的动态路由，无需频繁调整 DNS 记录。SubLink 在此基础上进一步引入数据库驱动的规则管理，使得入口层不必重载即可新增/修改跳转。
 
 ## 基础前提
 
@@ -8,15 +8,15 @@
 - 入口服务器终止 TLS，并将请求反向代理到后端（本项目中的 FastAPI 服务）。
 - 客户端请求必须携带正确的 `Host` 头，Cloudflare 等代理场景会自动保留该头部。
 
-## Yetla 的 Nginx 架构
+## SubLink 的 Nginx 架构
 
-1. **HTTPS 终止与统一跳转**：`infra/nginx/conf.d/yetla.upstream.conf` 定义了 `80`→`443` 的 301 跳转，以及在 `443` 端口加载挂载在 `/etc/nginx/ssl/` 下的证书。
+1. **HTTPS 终止与统一跳转**：`infra/nginx/conf.d/sublink.upstream.conf` 定义了 `80`→`443` 的 301 跳转，以及在 `443` 端口加载挂载在 `/etc/nginx/ssl/` 下的证书。
 2. **反代 FastAPI**：所有请求都会转发至 `backend:8000`，并透传 `Authorization`、`Host`、`X-Forwarded-*` 等头部，后端根据数据库规则决定返回 30x 重定向还是 404。
 3. **证书挂载机制**：入口脚本会在容器内 `/etc/nginx/ssl` 生成指向宿主机证书的符号链接，便于证书轮换。更新宿主机证书后执行 `docker compose restart nginx` 即可生效。
 4. **冒烟验证**：`scripts/proxy-smoke.sh` 通过模拟 Cloudflare 的代理请求验证 HTTP→HTTPS 跳转、Basic Auth 保护以及子域命中。
 5. **多域名映射**：FastAPI 的站点设置支持维护多个管理域名，后端会根据 `managed_domains` 生成 `www.` 映射表；Nginx 只需透传原始 Host，即可让不同域名共用同一套跳转与短链逻辑。
 
-与传统的 Nginx `map` 静态配置相比，Yetla 通过 FastAPI 接口维护子域与短链，命中时由后端返回目标地址并在数据库中记录访问次数。Nginx 本身只负责 TLS、日志与反向代理，降低了重新加载配置的复杂度。
+与传统的 Nginx `map` 静态配置相比，SubLink 通过 FastAPI 接口维护子域与短链，命中时由后端返回目标地址并在数据库中记录访问次数。Nginx 本身只负责 TLS、日志与反向代理，降低了重新加载配置的复杂度。
 
 ## 适用场景与扩展
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,6 +1,6 @@
-# Yetla Onboarding Guide
+# SubLink Onboarding Guide
 
-欢迎加入 Yetla 项目！本项目是一套可直接投入生产的自托管平台，用于集中管理二级域名跳转与短链接。当前仓库提供完整的 HTTPS 入口、带 HTMX 管理界面的 FastAPI 后端，以及覆盖部署、备份与冒烟验证的脚本，帮助你快速理解系统全貌并持续迭代。
+欢迎加入 SubLink 项目！本项目是一套可直接投入生产的自托管平台，用于集中管理二级域名跳转与短链接。当前仓库提供完整的 HTTPS 入口、带 HTMX 管理界面的 FastAPI 后端，以及覆盖部署、备份与冒烟验证的脚本，帮助你快速理解系统全貌并持续迭代。
 
 ## 项目背景与目标
 - **业务目标**：提供统一的平台管理自定义二级域名与短链接，对接 DNS、反向代理或重定向服务。
@@ -40,7 +40,7 @@
 
 ## 上手建议
 1. **启动生产环境**：按照根目录 `README.md` 的「快速开始」完成 `.env`、证书与 `docker compose up -d --build`，确认 `https://<域名>/admin` 可登录。
-2. **理解 Nginx 架构**：阅读 `infra/nginx/conf.d/yetla.upstream.conf` 以及入口脚本，掌握证书挂载、反代与自愈机制。
+2. **理解 Nginx 架构**：阅读 `infra/nginx/conf.d/sublink.upstream.conf` 以及入口脚本，掌握证书挂载、反代与自愈机制。
 3. **熟悉后端实现**：重点阅读 `backend/app/main.py`、`views.py` 与 `models.py`，了解 API、HTMX 模板与数据库迁移逻辑，尤其是用户 CRUD、密码修改与权限校验的依赖函数。
 4. **扩展流程与文档**：新增功能时，同步更新 `docs/` 下的设计说明与运维手册，保持文档与实现同步；涉及权限或 UI 变更时请验证移动端显示效果。
 5. **安全合规**：为生产环境配置强随机密码、`SESSION_SECRET` 与访问白名单，并评估进一步的审计与告警需求。

--- a/docs/backup-example.sh
+++ b/docs/backup-example.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
-# 示例备份脚本：供 cron 调度使用，将 yet.la 数据与日志归档后上传到远端存储。
+# 示例备份脚本：供 cron 调度使用，将 SubLink（yet.la）数据与日志归档后上传到远端存储。
 # 根据生产环境修改 STORAGE_CMD 以适配 rsync、rclone 或云厂商 CLI。
 
 set -euo pipefail
 
-YETLA_ROOT="/opt/yetla"
-BACKUP_ROOT="/var/backups/yetla"
+SUBLINK_ROOT="/opt/sublink"
+BACKUP_ROOT="/var/backups/sublink"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
-ARCHIVE_PATH="$BACKUP_ROOT/yetla-${TIMESTAMP}.tar.gz"
+ARCHIVE_PATH="$BACKUP_ROOT/sublink-${TIMESTAMP}.tar.gz"
 RETENTION_DAYS=7
 
 mkdir -p "$BACKUP_ROOT"
 
 # 打包数据卷与应用日志，可按需扩展包含更多目录。
 tar -czf "$ARCHIVE_PATH" \
-  -C "$YETLA_ROOT" data \
-  -C "$YETLA_ROOT" logs || { rm -f "$ARCHIVE_PATH"; exit 1; }
+  -C "$SUBLINK_ROOT" data \
+  -C "$SUBLINK_ROOT" logs || { rm -f "$ARCHIVE_PATH"; exit 1; }
 
 # 将归档同步到远端目标（示例：挂载的对象存储或备份服务器）。
-STORAGE_CMD=(rsync -av "$ARCHIVE_PATH" backup@example.com:/srv/backups/yetla/)
+STORAGE_CMD=(rsync -av "$ARCHIVE_PATH" backup@example.com:/srv/backups/sublink/)
 "${STORAGE_CMD[@]}"
 
 # 删除过期备份，保留最近 RETENTION_DAYS 天。
-find "$BACKUP_ROOT" -name 'yetla-*.tar.gz' -mtime +$((RETENTION_DAYS - 1)) -delete
+find "$BACKUP_ROOT" -name 'sublink-*.tar.gz' -mtime +$((RETENTION_DAYS - 1)) -delete

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -1,6 +1,6 @@
 # Nginx 子域路由配置
 
-该目录存放使用 Nginx 解析二级域名的示例配置。核心思想是：
+该目录存放 SubLink（yet.la）使用 Nginx 解析二级域名的示例配置。核心思想是：
 
 1. 通过 DNS 将 `*.yet.la` 指向同一台服务器（可以是 A 记录或 CNAME）。
 2. Nginx 根据请求头中的 `Host` 字段选择不同的 upstream，达到“子域内部分流”的目的。

--- a/infra/nginx/conf.d/subdomains.conf
+++ b/infra/nginx/conf.d/subdomains.conf
@@ -1,4 +1,4 @@
-# Yetla Nginx 配置示例：根据域名路由到默认 upstream，并为裸域名跳转到 www 子域。
+# SubLink Nginx 配置示例：根据域名路由到默认 upstream，并为裸域名跳转到 www 子域。
 
 # 定义默认 upstream。生产环境可改为指向真实服务或容器。
 upstream app_default {

--- a/infra/nginx/conf.d/sublink.upstream.conf
+++ b/infra/nginx/conf.d/sublink.upstream.conf
@@ -1,4 +1,4 @@
-# yet.la 生产入口，将所有请求转发到 backend 应用，并强制 HTTPS。
+# SubLink 生产入口（服务 yet.la 域名），将所有请求转发到 backend 应用，并强制 HTTPS。
 
 upstream backend_app {
     server backend:8000;

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bootstrap script for a fresh Ubuntu 22.04 VPS to run yet.la stack.
+# Bootstrap script for a fresh Ubuntu 22.04 VPS to run the SubLink (yet.la) stack.
 set -euo pipefail
 
 if [[ ${EUID} -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- rename documentation and repository references to the new SubLink branding while retaining the yet.la domain details
- update backend session cookie name and admin UI theme/fallback keys to use the SubLink prefix
- rename the Nginx upstream configuration file and adjust compose mounts for the new filename

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e657e48fe4832f972d172f116fbfd6